### PR TITLE
Resolve frontend asset paths against the package, not the CWD

### DIFF
--- a/frontend/config.py
+++ b/frontend/config.py
@@ -1,3 +1,19 @@
+from pathlib import Path
+
 backend_endpoint = "http://127.0.0.1:5000/"
 use_mock_data = False
 use_search = True
+
+# Absolute location of this frontend package. Asset paths must resolve against
+# it rather than the process CWD, so the app renders identically no matter
+# which directory streamlit is launched from.
+FRONTEND_ROOT = Path(__file__).resolve().parent
+
+
+def asset_path(relative: str) -> str:
+    """Resolve a frontend-relative path (e.g. ``./assets/...``) to an absolute one.
+
+    Absolute inputs are returned unchanged (``Path.__truediv__`` semantics), so
+    callers can pass either form.
+    """
+    return str((FRONTEND_ROOT / relative).resolve())

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -8,6 +8,7 @@ import streamlit as st
 from streamlit.errors import StreamlitAPIException
 
 from utils.state import initialize_session_state, change_selected_goal_id, save_persistent_state, load_persistent_state, _get_data_store_path
+from config import asset_path
 
 logger = logging.getLogger(__name__)
 
@@ -63,8 +64,8 @@ st.session_state.setdefault("_autosave_enabled", True)
 from components.chatbot import render_chatbot
 
 st.set_page_config(page_title="GenMentor", page_icon="🧠", layout="wide")
-st.logo("./assets/avatar.png")
-st.markdown('<style>' + open('./assets/css/main.css').read() + '</style>', unsafe_allow_html=True)
+st.logo(asset_path("./assets/avatar.png"))
+st.markdown('<style>' + open(asset_path('./assets/css/main.css')).read() + '</style>', unsafe_allow_html=True)
 
 if st.session_state.get("if_complete_onboarding", False) and not st.session_state.get("_navigated_lp_once", False):
     st.session_state["_navigated_lp_once"] = True

--- a/frontend/pages/knowledge_document.py
+++ b/frontend/pages/knowledge_document.py
@@ -11,13 +11,13 @@ from components.time_tracking import track_session_learning_start_time
 from utils.request_api import draft_knowledge_points, explore_knowledge_points, generate_document_quizzes, integrate_learning_document, update_learner_profile
 from utils.format import prepare_markdown_document
 from utils.state import get_current_session_uid, save_persistent_state
-from config import use_mock_data, use_search
+from config import use_mock_data, use_search, asset_path
 from assets.js.doc_reading import doc_reading_auto_scroll_js
 
 logger = logging.getLogger(__name__)
 
 
-st.markdown('<style>' + open('./assets/css/main.css').read() + '</style>', unsafe_allow_html=True)
+st.markdown('<style>' + open(asset_path('./assets/css/main.css')).read() + '</style>', unsafe_allow_html=True)
 
 
 def render_learning_content():
@@ -157,7 +157,7 @@ def render_content_preparation(goal):
     session_uid = get_current_session_uid()
     if use_mock_data:
         st.warning("Using mock data for knowledge document.")
-        file_path = "./assets/data_example/knowledge_document.json"
+        file_path = asset_path("./assets/data_example/knowledge_document.json")
         learning_content = load_knowledge_point_content(file_path)
         st.session_state["document_caches"][session_uid] = learning_content
         save_persistent_state()

--- a/frontend/utils/request_api.py
+++ b/frontend/utils/request_api.py
@@ -10,7 +10,7 @@ import json
 import httpx
 import streamlit as st
 
-from config import backend_endpoint, use_mock_data, use_search as default_use_search
+from config import backend_endpoint, use_mock_data, use_search as default_use_search, asset_path
 
 # Endpoint paths, keyed by the client function that calls them. Every entry here
 # must correspond to a route registered in backend/main.py.
@@ -52,7 +52,9 @@ def model_selection(llm_type=None):
 def make_post_request(api_name, data, mock_data_path=None, timeout=DEFAULT_TIMEOUT):
     """POST to the backend and return the decoded body, or ``None`` on failure."""
     if use_mock_data and mock_data_path:
-        with open(mock_data_path) as handle:
+        # Resolve against the frontend root, not the process CWD, so mock
+        # fixtures load no matter where streamlit was launched from.
+        with open(asset_path(mock_data_path)) as handle:
             return json.load(handle)
 
     backend_url = f"{backend_endpoint}{api_name}"


### PR DESCRIPTION
## Problem

Streamlit resolves relative paths against the process working directory. Launching the app from any directory other than `frontend/` (e.g. `streamlit run frontend/main.py` from the repo root) crashed the page script: `st.logo("./assets/avatar.png")` raised `MediaFileStorageError`, and the CSS load / mock-data fixtures would fail the same way.

## Fix

- `config.FRONTEND_ROOT` + `asset_path()` resolve frontend-relative paths against `__file__` — the same approach `utils/state.py` already uses for the data store.
- Applied to `st.logo` and `main.css` loads in `main.py` and `pages/knowledge_document.py`.
- Mock fixture paths are resolved centrally in `make_post_request`, so every existing and future call site is covered without per-site edits.

## Verification

- `asset_path('./assets/css/main.css')` resolves and opens correctly when evaluated from `$HOME`.
- Full app launched with cwd=$HOME: page renders completely (logo, styles, onboarding form) — previously this crashed with a traceback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)