### PR TITLE
Harden chatbot profile access; remove dead 503-error helper (#3)

### DIFF
--- a/frontend/components/chatbot.py
+++ b/frontend/components/chatbot.py
@@ -14,7 +14,9 @@ def ask_autor_chatbot():
         goal = st.session_state["to_add_goal"]
     else:
         goal = st.session_state["goals"][st.session_state["selected_goal_id"]]
-    learner_profile = goal["learner_profile"]
+    # The profile only exists once "Schedule Learning Path" has run; the tutor
+    # works fine without one, so default instead of crashing the dialog.
+    learner_profile = goal.get("learner_profile", "")
 
     messages = st.container(height=300)
     if prompt := st.chat_input("Ask me anything"):

--- a/frontend/utils/backend.py
+++ b/frontend/utils/backend.py
@@ -1,9 +1,0 @@
-import httpx
-import streamlit as st
-
-def request_backend(api_endpoint, data):
-    response = httpx.post(api_endpoint, json=data, timeout=360)
-    if response.status_code == 200:
-        return response.json()
-    else:
-        st.write("Failed to fetch data. Status code:", response.status_code)


### PR DESCRIPTION
Follow-up to #3 ("Failed to fetch data. Status code: 503" on the Skill Gap page after uploading a CV).

## Findings on current main

1. The exact message came from `utils/backend.py::request_backend` — **dead code with zero callers**. The current CV upload path (`views/onboarding.py`) extracts PDF text locally and never posts to that endpoint, so the 503 message can no longer be produced. The helper is deleted so it stops misleading debugging (it did exactly that in the issue thread).
2. The `goal["learner_profile"]` KeyError pointed out in the thread (`components/chatbot.py`) is **not reproducible on main**: `reset_to_add_goal()` always seeds the key, and a full chat round-trip with an empty profile succeeds. Nevertheless the direct access is now `goal.get("learner_profile", "")`, as suggested, so the dialog stays safe against any future minimal-dict path.

## Verification (isolated instance)

- With no learner profile created, the Ask Tutor dialog opens without error.
- A full tutor chat round-trip (search + RAG + LLM) returns a response.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)