### PR TITLE
Nav scrollspy, mobile menu close, accent unification, dead script removal

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,8 +35,8 @@
   <meta name="keywords" content="AI, Learning Path, Personalized Tutoring, Goal-oriented Learning, GenMentor, LLM">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>GenMentor</title>
-  <link rel="icon" type="image/x-icon" href="static/images/favicon.png">
+  <title>GenMentor: LLM-powered &amp; Goal-oriented Tutoring System</title>
+  <link rel="icon" type="image/png" href="static/images/favicon.png">
   <link href="https://fonts.googleapis.com/css?family=Google+Sans|Noto+Sans|Castoro" rel="stylesheet">
 
   <link rel="stylesheet" href="static/css/bulma.min.css">
@@ -50,12 +50,10 @@
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-  <script src="https://documentcloud.adobe.com/view-sdk/main.js"></script>
   <script defer src="static/js/fontawesome.all.min.js"></script>
   <script src="static/js/bulma-carousel.min.js"></script>
   <script src="static/js/bulma-slider.min.js"></script>
   <script src="static/js/index.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 
 <body>

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1311,3 +1311,31 @@ html[data-theme='dark'] .footer-attribution {
 .bibtex-box pre {
   overflow-x: auto;
 }
+
+/* ---------- Nav & control refinements ---------- */
+
+/* Unify the primary accent (navbar Paper button, primary tags) with the
+   site's blue; Bulma's default teal reads as a foreign accent next to
+   the blue hover/badge system. */
+.button.is-primary {
+  background-color: hsl(204, 86%, 47%);
+}
+
+.button.is-primary:hover,
+.button.is-primary:focus {
+  background-color: hsl(204, 86%, 41%);
+}
+
+.tag.is-primary {
+  background-color: hsl(204, 86%, 47%);
+}
+
+/* Carousel dots: black-on-dark was invisible; light grey with an
+   accent-blue active dot in dark mode. */
+html[data-theme='dark'] .slider-pagination .slider-page {
+  background-color: #6b6e78;
+}
+
+html[data-theme='dark'] .slider-pagination .slider-page.is-active {
+  background-color: hsl(204, 86%, 63%);
+}

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -169,3 +169,40 @@ document.addEventListener('DOMContentLoaded', () => {
     attach();
   }
 })();
+
+// Scrollspy: highlight the nav item whose section is in view, using the
+// .navbar-item.is-active styles that already exist in index.css.
+document.addEventListener('DOMContentLoaded', () => {
+  const navLinks = Array.from(document.querySelectorAll('.navbar-start a.navbar-item[href^="#"]'));
+  const linkById = {};
+  navLinks.forEach(link => { linkById[link.getAttribute('href').slice(1)] = link; });
+  const sections = Object.keys(linkById)
+    .map(id => document.getElementById(id))
+    .filter(Boolean);
+
+  // Close the mobile menu after tapping a nav item; Bulma leaves it open.
+  navLinks.forEach(link => {
+    link.addEventListener('click', () => {
+      const burger = document.querySelector('.navbar-burger');
+      const menu = document.getElementById('navbarBasic');
+      if (burger && menu && menu.classList.contains('is-active')) {
+        burger.classList.remove('is-active');
+        menu.classList.remove('is-active');
+        burger.setAttribute('aria-expanded', 'false');
+      }
+    });
+  });
+
+  if (!('IntersectionObserver' in window) || !sections.length) return;
+  const setActive = (id) => {
+    navLinks.forEach(link => link.classList.remove('is-active'));
+    const link = linkById[id];
+    if (link) link.classList.add('is-active');
+  };
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) setActive(entry.target.id);
+    });
+  }, { rootMargin: '-25% 0px -65% 0px', threshold: 0 });
+  sections.forEach(section => observer.observe(section));
+});


### PR DESCRIPTION
Second refinement pass for the project page (follow-up to the dark-theme and design-polish rounds).

## Nav
- **Scrollspy**: `index.css` has `.navbar-item.is-active` styles (blue text + underline) that nothing ever applied — the nav was static while scrolling. Added an IntersectionObserver-based scrollspy mapping the five nav anchors to their sections.
- **Mobile menu**: Bulma leaves the burger menu open after tapping a nav item; it now closes on navigation.
- `<title>` expanded to the full site name; favicon `type` corrected to `image/png`.

## Accent unification
`.button.is-primary` / `.tag.is-primary` move from Bulma's default teal to the site's blue (`hsl(204, 86%, 47%)`), matching the venue badge, hover accents and the demo note. The navbar Paper button no longer reads as a foreign accent.

## Dark mode
Carousel pagination dots were `#000` — invisible on the dark background. Now grey with an accent-blue active dot in dark mode.

## Performance
`chart.js` and the Adobe View SDK were loaded render-blocking in `<head>` with **zero usage** on the page (verified: no `Chart(` references; the poster iframe that would have used the SDK was removed earlier). Both script tags dropped.

## Verified locally (desktop dark/light + 390px mobile)
- scrolling to Framework highlights the Framework nav item (screenshot-checked)
- burger menu opens, nav tap navigates AND closes the menu
- carousel dots visible with active accent in dark mode
- page loads without the two dead scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)