### PR TITLE
feat: UX round — knowledge sources page, quiz submit-all + review list, pipeline auto-refresh, SQLite persistence

### DIFF
--- a/backend/base/search_rag.py
+++ b/backend/base/search_rag.py
@@ -275,6 +275,49 @@ class SearchRagManager:
             return []
         return self.kb_vectorstore.similarity_search(query, k=k, filter={KB_GOAL_KEY: str(goal_id)})
 
+    def list_kb(self, goal_id: str) -> List[Dict[str, Any]]:
+        """Summarise the goal's knowledge base grouped by source page."""
+        if self.kb_vectorstore is None:
+            return []
+        fetched = self.kb_vectorstore._collection.get(
+            where={KB_GOAL_KEY: str(goal_id)}, include=["metadatas"]
+        )
+        by_source: Dict[str, Dict[str, Any]] = {}
+        for doc_id, meta in zip(fetched.get("ids") or [], fetched.get("metadatas") or []):
+            meta = meta or {}
+            url = str(meta.get("source") or "").strip()
+            if not url:
+                continue
+            entry = by_source.setdefault(url, {
+                "source": url,
+                "title": str(meta.get("title") or "") or url,
+                "pinned_at": float(meta.get(CREATED_AT_KEY, 0.0) or 0.0),
+                "chunk_ids": [],
+            })
+            entry["chunk_ids"].append(doc_id)
+            entry["pinned_at"] = max(entry["pinned_at"], float(meta.get(CREATED_AT_KEY, 0.0) or 0.0))
+        # Most recently pinned first; each entry carries its chunk ids so the
+        # UI can offer a precise unpin.
+        return sorted(by_source.values(), key=lambda e: e["pinned_at"], reverse=True)
+
+    def unpin_kb(self, goal_id: str, source: Optional[str] = None, chunk_ids: Optional[List[str]] = None) -> int:
+        """Remove pages (by source url) or specific chunks from a goal's KB."""
+        if self.kb_vectorstore is None:
+            return 0
+        collection = self.kb_vectorstore._collection
+        ids: List[str] = list(chunk_ids or [])
+        if source:
+            fetched = collection.get(
+                where={"$and": [{KB_GOAL_KEY: str(goal_id)}, {"source": str(source)}]},
+                include=[],
+            )
+            ids.extend(fetched.get("ids") or [])
+        if not ids:
+            return 0
+        collection.delete(ids=ids)
+        logger.info("Unpinned %d KB chunks for goal %s", len(ids), goal_id)
+        return len(ids)
+
     def prune_kb(self, goal_id: str) -> int:
         """Cap a goal's KB at kb_max_chunks_per_goal, evicting oldest first."""
         if self.kb_vectorstore is None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -198,6 +198,27 @@ def chat_with_tutor_stream(request: ChatWithTutorRequest):  # noqa: F405
     return StreamingResponse(generate(), media_type="text/plain; charset=utf-8")
 
 
+@app.get("/knowledge-base/{goal_id}")
+async def knowledge_base(goal_id: str):
+    """List the pages pinned into a goal's knowledge base (newest first)."""
+    manager = get_search_rag_manager()
+    if manager is None:
+        return {"goal_id": goal_id, "sources": []}
+    return {"goal_id": goal_id, "sources": manager.list_kb(goal_id)}
+
+
+@app.delete("/knowledge-base/{goal_id}")
+async def knowledge_base_unpin(goal_id: str, source: Optional[str] = None):
+    """Remove a page (by its url) from the goal's knowledge base."""
+    if not source:
+        raise HTTPException(status_code=400, detail="A `source` url is required to unpin.")
+    manager = get_search_rag_manager()
+    if manager is None:
+        raise HTTPException(status_code=503, detail="Knowledge base is not available.")
+    removed = manager.unpin_kb(goal_id, source=source)
+    return {"goal_id": goal_id, "removed_chunks": removed}
+
+
 @app.post("/refine-learning-goal")
 async def refine_learning_goal(request: LearningGoalRefinementRequest):  # noqa: F405
     try:

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -8,6 +8,7 @@ import streamlit as st
 from streamlit.errors import StreamlitAPIException
 
 from utils.state import initialize_session_state, save_persistent_state, _get_data_store_path
+from utils import data_store
 from config import asset_path
 
 logger = logging.getLogger(__name__)
@@ -45,17 +46,19 @@ def _switch_page(page: str) -> bool:
 
 
 def _reset_data_store(path: Path) -> None:
-    """Archive the data store under a timestamped name, then delete it.
+    """Archive the SQLite data store under a timestamped name, then delete it.
 
     The archive is written first on purpose: if it cannot be created the store is
-    left in place rather than destroyed without a backup.
+    left in place rather than destroyed without a backup. WAL/SHM siblings are
+    removed alongside the db file.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     if not path.exists():
         return
     ts = datetime.now().strftime("%Y%m%d-%H%M%S")
-    shutil.copy2(str(path), str(path.parent / f"data_storage-{ts}.json"))
-    path.unlink()
+    shutil.copy2(str(path), str(path.parent / f"data_storage-{ts}.db"))
+    for sibling in data_store.db_files(path):
+        sibling.unlink(missing_ok=True)
 
 
 initialize_session_state()
@@ -113,6 +116,7 @@ knowledge_document = st.Page("views/knowledge_document.py", title="Resume Learni
 learner_profile = st.Page("views/learner_profile.py", title="My Profile", icon=":material/person:", default=False, url_path="learner_profile")
 goal_management = st.Page("views/goal_management.py", title="Goal Management", icon=":material/flag:", default=False, url_path="goal_management")
 dashboard = st.Page("views/dashboard.py", title="Analytics Dashboard", icon=":material/browse:", default=False, url_path="dashboard")
+sources = st.Page("views/sources.py", title="Knowledge Sources", icon=":material/source:", default=False, url_path="sources")
 
 # Learning Analytics Dashboard
 if not st.session_state["if_complete_onboarding"]:
@@ -150,11 +154,13 @@ else:
 
         if all_skill != 0:
             mastery_rate = learned_skill / all_skill
+            # Entries are {"ts", "rate"} — real timestamps persisted in the
+            # mastery_history table (the dashboard plots against them).
             if not history:
-                history.append(mastery_rate)
+                history.append({"ts": time.time(), "rate": mastery_rate})
             elif time.time() - goal['start_time'] > MASTERY_SNAPSHOT_INTERVAL:
                 goal['start_time'] = time.time()
-                history.append(mastery_rate)
+                history.append({"ts": time.time(), "rate": mastery_rate})
 
         if len(history) > MASTERY_HISTORY_LENGTH:
             del history[:-MASTERY_HISTORY_LENGTH]

--- a/frontend/utils/data_store.py
+++ b/frontend/utils/data_store.py
@@ -1,0 +1,258 @@
+"""SQLite-backed persistence for the frontend session state.
+
+Replaces the single JSON file (user_data/data_store.json): WAL journaling and
+per-key upserts make concurrent tabs last-write-wins per key instead of
+clobbering the whole file, and the mastery history becomes real-timestamped
+rows instead of wall-clock samples.
+
+Layout (key -> table routing):
+    goals                    -> goals(id, data)
+    learned_skills_history   -> mastery_history(goal_id, ts, rate)
+    document_caches /        -> blobs(kind, uid, data)   one row per uid
+    content_pipeline_state /
+    session_learning_times
+    quiz_results_* (any key starting with that prefix)
+    everything else          -> kv(key, value)
+
+The first load migrates an existing data_store.json in place and renames it
+to .migrated (kept as a backup).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS kv (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+CREATE TABLE IF NOT EXISTS goals (id INTEGER PRIMARY KEY, data TEXT NOT NULL);
+CREATE TABLE IF NOT EXISTS blobs (
+    kind TEXT NOT NULL,
+    uid TEXT NOT NULL,
+    data TEXT NOT NULL,
+    PRIMARY KEY (kind, uid)
+);
+CREATE TABLE IF NOT EXISTS mastery_history (
+    goal_id INTEGER NOT NULL,
+    ts REAL NOT NULL,
+    rate REAL NOT NULL,
+    PRIMARY KEY (goal_id, ts)
+);
+"""
+
+# Top-level session keys whose value is a {uid: blob} mapping.
+_DICT_OF_BLOBS = {"document_caches", "content_pipeline_state", "session_learning_times"}
+_QUIZ_PREFIX = "quiz_results_"
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, timeout=5.0)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=3000")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    return conn
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(_SCHEMA)
+    conn.commit()
+
+
+def _dump(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _load(value: str) -> Any:
+    return json.loads(value)
+
+
+def save_snapshot(path: Path, snapshot: Dict[str, Any]) -> bool:
+    """Persist one full state snapshot, routing each key to its table."""
+    try:
+        conn = _connect(path)
+        try:
+            _ensure_schema(conn)
+            with conn:
+                # goals (upsert; drop rows whose id disappeared this session)
+                goals = snapshot.get("goals") or []
+                keep_ids = []
+                for goal in goals if isinstance(goals, list) else []:
+                    gid = goal.get("id") if isinstance(goal, dict) else None
+                    if gid is None:
+                        continue
+                    keep_ids.append(int(gid))
+                    conn.execute(
+                        "INSERT INTO goals(id, data) VALUES(?, ?) "
+                        "ON CONFLICT(id) DO UPDATE SET data=excluded.data",
+                        (int(gid), _dump(goal)),
+                    )
+                if keep_ids:
+                    conn.execute(
+                        f"DELETE FROM goals WHERE id NOT IN ({','.join('?' * len(keep_ids))})",
+                        keep_ids,
+                    )
+                else:
+                    conn.execute("DELETE FROM goals")
+
+                # mastery history: replace-all (small table, real timestamps)
+                conn.execute("DELETE FROM mastery_history")
+                history = snapshot.get("learned_skills_history") or {}
+                if isinstance(history, dict):
+                    rows = []
+                    for gid, entries in history.items():
+                        if not isinstance(entries, list):
+                            continue
+                        for entry in entries:
+                            if isinstance(entry, dict) and "rate" in entry:
+                                rows.append((int(gid), float(entry.get("ts", 0.0) or 0.0),
+                                             float(entry["rate"])))
+                            elif isinstance(entry, (int, float)):
+                                # legacy plain-rate entries: stamp them now
+                                rows.append((int(gid), time.time(), float(entry)))
+                    conn.executemany(
+                        "INSERT OR REPLACE INTO mastery_history(goal_id, ts, rate) VALUES(?, ?, ?)",
+                        rows,
+                    )
+
+                # uid-keyed blob maps and quiz_results_* keys
+                for key in _DICT_OF_BLOBS:
+                    mapping = snapshot.get(key)
+                    if not isinstance(mapping, dict):
+                        continue
+                    conn.execute("DELETE FROM blobs WHERE kind=?", (key,))
+                    conn.executemany(
+                        "INSERT OR REPLACE INTO blobs(kind, uid, data) VALUES(?, ?, ?)",
+                        [(key, str(uid), _dump(blob)) for uid, blob in mapping.items()],
+                    )
+                for key, value in snapshot.items():
+                    if key.startswith(_QUIZ_PREFIX):
+                        conn.execute(
+                            "INSERT OR REPLACE INTO blobs(kind, uid, data) VALUES(?, ?, ?)",
+                            ("quiz_results", key, _dump(value)),
+                        )
+
+                # simple keys -> kv
+                skip = _DICT_OF_BLOBS | {"goals", "learned_skills_history"}
+                kv_rows = [
+                    (key, _dump(value))
+                    for key, value in snapshot.items()
+                    if key not in skip and not key.startswith(_QUIZ_PREFIX)
+                ]
+                conn.executemany(
+                    "INSERT INTO kv(key, value) VALUES(?, ?) "
+                    "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+                    kv_rows,
+                )
+        finally:
+            conn.close()
+        return True
+    except (sqlite3.Error, TypeError, ValueError) as exc:
+        logger.error("Could not persist state to %s: %s", path, exc, exc_info=True)
+        return False
+
+
+def load_snapshot(path: Path) -> Dict[str, Any]:
+    """Read the whole store back into the snapshot dict shape.
+
+    Migrates an existing JSON store on first use. Returns {} when there is
+    nothing to restore (fresh install or unreadable store — logged).
+    """
+    legacy_json = path.parent / "data_store.json"
+    try:
+        conn = _connect(path)
+        try:
+            _ensure_schema(conn)
+            fresh = conn.execute("SELECT COUNT(*) FROM kv").fetchone()[0] == 0 \
+                and conn.execute("SELECT COUNT(*) FROM goals").fetchone()[0] == 0
+            if fresh and legacy_json.exists():
+                _migrate_json(conn, legacy_json)
+            snapshot: Dict[str, Any] = {}
+
+            for key, value in conn.execute("SELECT key, value FROM kv"):
+                snapshot[key] = _load(value)
+            snapshot["goals"] = [
+                _load(row[0]) for row in
+                conn.execute("SELECT data FROM goals ORDER BY id")
+            ]
+            history: Dict[str, List[Dict[str, Any]]] = {}
+            for gid, ts, rate in conn.execute(
+                "SELECT goal_id, ts, rate FROM mastery_history ORDER BY goal_id, ts"
+            ):
+                history.setdefault(str(gid), []).append({"ts": ts, "rate": rate})
+            snapshot["learned_skills_history"] = history
+
+            for kind in _DICT_OF_BLOBS:
+                mapping = {
+                    uid: _load(data) for uid, data in
+                    conn.execute("SELECT uid, data FROM blobs WHERE kind=?", (kind,))
+                }
+                if mapping or kind in snapshot:
+                    snapshot[kind] = mapping
+            for uid_key, data in conn.execute(
+                "SELECT uid, data FROM blobs WHERE kind='quiz_results'"
+            ):
+                snapshot[uid_key] = _load(data)
+            return snapshot
+        finally:
+            conn.close()
+    except (sqlite3.Error, ValueError) as exc:
+        logger.error("Could not read persisted state from %s: %s", path, exc, exc_info=True)
+        return {}
+
+
+def _migrate_json(conn: sqlite3.Connection, legacy_json: Path) -> None:
+    """Import the old flat-JSON store once, then park it as a backup."""
+    try:
+        data = json.loads(legacy_json.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        logger.error("Legacy store %s unreadable, skipping migration: %s", legacy_json, exc)
+        return
+    if not isinstance(data, dict):
+        logger.error("Legacy store %s is not a JSON object, skipping migration.", legacy_json)
+        return
+    with conn:
+        for key, value in data.items():
+            if key == "goals" and isinstance(value, list):
+                for goal in value:
+                    if isinstance(goal, dict) and goal.get("id") is not None:
+                        conn.execute(
+                            "INSERT OR REPLACE INTO goals(id, data) VALUES(?, ?)",
+                            (int(goal["id"]), _dump(goal)),
+                        )
+            elif key == "learned_skills_history" and isinstance(value, dict):
+                for gid, entries in value.items():
+                    if isinstance(entries, list):
+                        for entry in entries:
+                            ts, rate = (time.time(), float(entry)) if isinstance(entry, (int, float)) \
+                                else (float(entry.get("ts", 0.0) or 0.0), float(entry.get("rate", 0.0)))
+                            conn.execute(
+                                "INSERT OR REPLACE INTO mastery_history(goal_id, ts, rate) VALUES(?, ?, ?)",
+                                (int(gid), ts, rate),
+                            )
+            elif key in _DICT_OF_BLOBS and isinstance(value, dict):
+                conn.executemany(
+                    "INSERT OR REPLACE INTO blobs(kind, uid, data) VALUES(?, ?, ?)",
+                    [(key, str(uid), _dump(blob)) for uid, blob in value.items()],
+                )
+            else:
+                conn.execute(
+                    "INSERT OR REPLACE INTO kv(key, value) VALUES(?, ?)", (key, _dump(value))
+                )
+    backup = legacy_json.with_suffix(".json.migrated")
+    try:
+        legacy_json.rename(backup)
+        logger.info("Migrated legacy JSON store to SQLite; original kept at %s", backup)
+    except OSError as exc:
+        logger.warning("Migrated store but could not rename %s: %s", legacy_json, exc)
+
+
+def db_files(path: Path) -> List[Path]:
+    """The db plus its WAL/SHM siblings (for archive/reset flows)."""
+    return [path, Path(str(path) + "-wal"), Path(str(path) + "-shm")]

--- a/frontend/utils/request_api.py
+++ b/frontend/utils/request_api.py
@@ -59,6 +59,30 @@ def active_backend_endpoint() -> str:
     return endpoint.rstrip("/") + "/"
 
 
+def kb_sources(goal_id):
+    """List the pages pinned into a goal's knowledge base."""
+    url = f"{active_backend_endpoint()}knowledge-base/{goal_id}"
+    try:
+        response = httpx.get(url, timeout=30)
+    except httpx.HTTPError as exc:
+        st.error(f"Could not reach the backend at {url}: {exc}")
+        return []
+    if response.status_code != 200:
+        return []
+    return response.json().get("sources", [])
+
+
+def kb_unpin(goal_id, source):
+    """Remove a page from the goal's knowledge base; True on success."""
+    url = f"{active_backend_endpoint()}knowledge-base/{goal_id}"
+    try:
+        response = httpx.request("DELETE", url, params={"source": source}, timeout=30)
+    except httpx.HTTPError as exc:
+        st.error(f"Could not reach the backend at {url}: {exc}")
+        return False
+    return response.status_code == 200
+
+
 def make_post_request(api_name, data, mock_data_path=None, timeout=DEFAULT_TIMEOUT):
     """POST to the backend and return the decoded body, or ``None`` on failure."""
     if use_mock_data and mock_data_path:

--- a/frontend/utils/state.py
+++ b/frontend/utils/state.py
@@ -1,9 +1,9 @@
 import streamlit as st
-from collections import defaultdict
 import config
-import json
 import logging
 from pathlib import Path
+
+from utils import data_store
 
 logger = logging.getLogger(__name__)
 
@@ -38,48 +38,49 @@ PERSIST_KEYS = [
 
 
 def _get_data_store_path():
-    return Path(__file__).resolve().parents[1] / "user_data" / "data_store.json"
+    """SQLite store (WAL). The pre-SQLite JSON store auto-migrates on first load."""
+    return Path(__file__).resolve().parents[1] / "user_data" / "data_store.db"
+
+
+def _persistable_keys():
+    """PERSIST_KEYS plus any quiz_results_* keys currently in session state.
+
+    Quiz results live under dynamic per-session keys, so they are picked up by
+    prefix instead of a static list — completing a session after an app restart
+    must still carry the quiz data into the profile update.
+    """
+    return list(PERSIST_KEYS) + [
+        k for k in st.session_state if k.startswith("quiz_results_")
+    ]
 
 
 def load_persistent_state():
-    """Load persisted keys from a local JSON file into st.session_state.
+    """Restore persisted keys from the SQLite store into st.session_state.
 
-    Only keys listed in PERSIST_KEYS will be restored. Returns False if there is
-    nothing to restore or the store could not be read; a store that exists but is
-    unreadable or corrupt is logged rather than ignored.
+    Only keys listed in PERSIST_KEYS (plus quiz_results_*) are restored.
+    Returns False if there is nothing to restore or the store could not be
+    read; a store that exists but is unreadable is logged rather than ignored.
     """
-    path = _get_data_store_path()
-    if not path.exists():
+    snapshot = data_store.load_snapshot(_get_data_store_path())
+    if not snapshot:
         return False
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError) as exc:
-        logger.error("Could not read persisted state from %s: %s", path, exc, exc_info=True)
-        return False
-    if not isinstance(data, dict):
-        logger.error("Persisted state at %s is not a JSON object (got %s)", path, type(data).__name__)
-        return False
-    for k, v in data.items():
-        if k in PERSIST_KEYS:
+    restored = False
+    for k, v in snapshot.items():
+        if k in PERSIST_KEYS or k.startswith("quiz_results_"):
             st.session_state[k] = v
-    return True
+            restored = True
+    return restored
 
 
 def save_persistent_state():
-    """Save whitelisted st.session_state keys to a local JSON file.
+    """Persist whitelisted st.session_state keys to the SQLite store.
 
     Returns True on success. Failures are logged and reported as False; callers
     that can show UI (see `_autosave` in main.py) surface them to the user.
     """
-    path = _get_data_store_path()
-    data = {k: st.session_state[k] for k in PERSIST_KEYS if k in st.session_state}
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
-        return True
-    except (OSError, TypeError, ValueError) as exc:
-        logger.error("Could not persist state to %s: %s", path, exc, exc_info=True)
-        return False
+    keys = _persistable_keys()
+    snapshot = {k: st.session_state[k] for k in keys if k in st.session_state}
+    return data_store.save_snapshot(_get_data_store_path(), snapshot)
 
 
 def initialize_session_state():
@@ -155,6 +156,8 @@ def initialize_session_state():
     if "to_add_goal" not in st.session_state:
         reset_to_add_goal()
 
+    # {goal_id: [{"ts": epoch, "rate": 0..1}, ...]} — real timestamps, kept
+    # in the mastery_history table; legacy plain-rate lists auto-migrate.
     if 'learned_skills_history' not in st.session_state:
         st.session_state['learned_skills_history'] = {}
 

--- a/frontend/views/dashboard.py
+++ b/frontend/views/dashboard.py
@@ -142,10 +142,17 @@ def render_session_learning_timeseries(goal):
 def render_mastery_skills_timeseries(goal):
     st.markdown("#### Mastery Skills Timeseries")
     st.write("View the learning progress over time.")
-    time_values = [i * 10 for i in range(len(st.session_state['learned_skills_history'][goal['id']]))]
+    # Entries are {"ts", "rate"} with real timestamps (persisted in
+    # mastery_history); the x axis is minutes since the first sample.
+    entries = [e for e in st.session_state['learned_skills_history'].get(goal['id'], [])
+               if isinstance(e, dict) and 'rate' in e]
+    if not entries:
+        st.info("No mastery history yet — it accumulates as you learn.")
+        return
+    t0 = entries[0].get("ts", 0.0) or 0.0
     char_data = pd.DataFrame({
-        'Mastery Rate': st.session_state['learned_skills_history'][goal['id']],
-        'Time': time_values,
+        'Mastery Rate': [float(e['rate']) for e in entries],
+        'Time': [round((float(e.get('ts', t0)) - t0) / 60.0, 1) for e in entries],
     })
     st.line_chart(char_data, x='Time', y='Mastery Rate')
     

--- a/frontend/views/knowledge_document.py
+++ b/frontend/views/knowledge_document.py
@@ -170,6 +170,88 @@ def render_session_details(goal):
 # ---------------------------------------------------------------------------
 
 PIPELINE_STAGE_KEYS = ("knowledge_points", "knowledge_drafts", "document_structure")
+PIPELINE_TOTAL_STAGES = 4
+PIPELINE_STAGE_LABELS = {
+    "knowledge_points": "🔍 Knowledge points",
+    "knowledge_drafts": "📝 Knowledge point drafts",
+    "document_structure": "📚 Knowledge document",
+}
+PIPELINE_STAGE_RUNNING_LABELS = {
+    "knowledge_points": "🔍 Exploring knowledge points…",
+    "knowledge_drafts": "📝 Drafting knowledge points…",
+    "document_structure": "📚 Integrating knowledge document…",
+    "_quizzes": "🎯 Generating document quizzes…",
+}
+
+
+def pipeline_progress_snapshot(pipeline_state, document_cached=False):
+    """Compute the progress read-out for an in-flight content pipeline.
+
+    Pure helper (no Streamlit, no mutation of its arguments) so the fragment
+    below can re-run it every few seconds against the latest checkpoint
+    state. Returns ``None`` when there is nothing to show — no pipeline state
+    for the session, or a cached document with nothing checkpointed — which
+    makes a stale fragment fire a no-op. Otherwise::
+
+        {"completed": 0-3, "in_flight_stage": 1-4, "total": 4,
+         "restored_lines": [...], "status_line": str}
+
+    ``restored_lines`` describe the checkpointed stages ("Stage 2/4 📝
+    Knowledge point drafts ✓ restored"); ``status_line`` describes the stage
+    the main script run is currently executing.
+    """
+    if pipeline_state is None:
+        return None
+    state = pipeline_state if isinstance(pipeline_state, dict) else {}
+    restored = [
+        (stage, key)
+        for stage, key in enumerate(PIPELINE_STAGE_KEYS, start=1)
+        if state.get(key) is not None
+    ]
+    if not restored and document_cached:
+        return None
+    restored_lines = [
+        f"Stage {stage}/{PIPELINE_TOTAL_STAGES} {PIPELINE_STAGE_LABELS[key]} ✓ restored"
+        for stage, key in restored
+    ]
+    in_flight_stage = min(len(restored) + 1, PIPELINE_TOTAL_STAGES)
+    if in_flight_stage <= len(PIPELINE_STAGE_KEYS):
+        running_label = PIPELINE_STAGE_RUNNING_LABELS[PIPELINE_STAGE_KEYS[in_flight_stage - 1]]
+    else:
+        running_label = PIPELINE_STAGE_RUNNING_LABELS["_quizzes"]
+    return {
+        "completed": len(restored),
+        "in_flight_stage": in_flight_stage,
+        "total": PIPELINE_TOTAL_STAGES,
+        "restored_lines": restored_lines,
+        "status_line": f"Stage {in_flight_stage}/{PIPELINE_TOTAL_STAGES} {running_label}",
+    }
+
+
+@st.fragment(run_every="5s")
+def render_pipeline_progress(session_uid):
+    """Auto-refreshing progress area for the content preparation pipeline.
+
+    Display only: the heavy generation runs on the main script run (see
+    ``render_content_preparation``) and checkpoints into session state, which
+    this fragment re-reads every 5 seconds so an in-flight pipeline visibly
+    advances without user interaction. When the completed document cache
+    appears while the pipeline is still flagged as in flight, a full app
+    rerun swaps the page over to the document view. A fire without pipeline
+    state renders nothing.
+    """
+    document_cached = bool((st.session_state.get("document_caches") or {}).get(session_uid, False))
+    pipeline_state = (st.session_state.get("content_pipeline_state") or {}).get(session_uid)
+    snapshot = pipeline_progress_snapshot(pipeline_state, document_cached)
+    if snapshot is None:
+        return
+    if document_cached:
+        st.rerun(scope="app")
+        return
+    st.progress(snapshot["in_flight_stage"] / snapshot["total"])
+    st.write(snapshot["status_line"])
+    for line in snapshot["restored_lines"]:
+        st.caption(line)
 
 
 def next_pipeline_stage(pipeline_state):
@@ -218,6 +300,10 @@ def render_content_preparation(goal):
     # checkpointed stage instead of restarting the pipeline from scratch.
     pipeline_state = st.session_state["content_pipeline_state"].setdefault(session_uid, {})
 
+    # Progress read-out only: it refreshes itself every 5 seconds while the
+    # stages below run on this main script run and checkpoint their results.
+    render_pipeline_progress(session_uid)
+
     knowledge_points = None
     if next_pipeline_stage(pipeline_state) == "knowledge_points":
         with st.spinner("Stage 1/4 - Exploring knowledge Points..."):
@@ -233,8 +319,8 @@ def render_content_preparation(goal):
         _checkpoint_pipeline_stage(session_uid, "knowledge_points", knowledge_points)
         st.success("Stage 1/4 🔍 Knowledge points explored successfully.")
     else:
+        # Restored stages are reported by render_pipeline_progress above.
         knowledge_points = pipeline_state["knowledge_points"]
-        st.info("Stage 1/4 🔍 Knowledge points restored from your previous run.")
     with st.expander("View Explored Knowledge Points", expanded=False):
         for kp in knowledge_points:
             st.write(f"- {kp['name']} (`{kp['type']}`)")
@@ -258,7 +344,6 @@ def render_content_preparation(goal):
         st.success("Stage 2/4 📝 Knowledge points drafted successfully.")
     else:
         knowledge_drafts = pipeline_state["knowledge_drafts"]
-        st.info("Stage 2/4 📝 Knowledge point drafts restored from your previous run.")
     document_structure = None
     if next_pipeline_stage(pipeline_state) == "document_structure":
         with st.spinner("Stage 3/4 - Integrating knowledge document..."):
@@ -286,7 +371,6 @@ def render_content_preparation(goal):
         if learning_document is None:
             st.error("Failed to integrate knowledge document.")
             return
-        st.info("Stage 3/4 📚 Knowledge document restored from your previous run.")
     learning_content = {"document": learning_document}
     with st.spinner("Stage 4/4 - Generating document quizzes..."):
         quizzes = generate_document_quizzes(
@@ -482,14 +566,32 @@ def _resolve_correct_option(options, correct):
 
 QUIZ_RESULT_TYPES = ("single_choice", "multiple_choice", "true_false", "short_answer")
 QUIZ_RESULTS_KEY_PREFIX = "quiz_results_"
-# Multiple-choice correctness is only known at Submit time, and a bare button
-# click does not survive reruns, so submitted results are latched by question
-# index inside the stored results dict (private key, never sent as-is).
-SUBMITTED_MULTIPLE_CHOICE_KEY = "_submitted_multiple_choice"
+# All questions are judged together when "Submit Answers" is pressed, and a
+# bare button click does not survive reruns, so the judged per-question
+# verdicts are latched inside the stored results dict (private key, never
+# sent as-is to the profiler).
+SUBMITTED_ANSWERS_KEY = "_submitted_answers"
+# Wrong questions accumulate per goal for later review. The in-session copy
+# lives under QUIZ_REVIEW_LIST_KEY and is mirrored after every update into a
+# quiz_results_review_{goal_id} key, which the persistence layer auto-picks
+# (goal ids are normalised to strings because JSON round-trips do that to
+# int dict keys anyway).
+QUIZ_REVIEW_LIST_KEY = "quiz_review_list"
+# (kind, quiz_data list key, widget key prefix) in question render order.
+QUIZ_KIND_FIELDS = (
+    ("single_choice", "single_choice_questions", "single_"),
+    ("multiple_choice", "multiple_choice_questions", "multi_"),
+    ("true_false", "true_false_questions", "tf_"),
+    ("short_answer", "short_answer_questions", "short_"),
+)
 
 
 def quiz_results_state_key(session_uid):
     return f"{QUIZ_RESULTS_KEY_PREFIX}{session_uid}"
+
+
+def quiz_review_state_key(goal_id):
+    return f"{QUIZ_RESULTS_KEY_PREFIX}review_{goal_id}"
 
 
 def new_quiz_results():
@@ -548,6 +650,171 @@ def merge_quiz_performance(feedback_data, quiz_performance):
     return payload
 
 
+def _quiz_verdict(answered, display_correct):
+    """The per-question verdict shown after Submit ("unanswered" when skipped)."""
+    if not answered:
+        return "unanswered"
+    return "correct" if display_correct else "incorrect"
+
+
+def format_expected_answer(expected):
+    """Render an expected answer (option text, list of options, or text) inline."""
+    if expected is None:
+        return ""
+    if isinstance(expected, (list, tuple)):
+        return ", ".join(str(item) for item in expected)
+    return str(expected)
+
+
+def judge_quiz_submissions(quiz_data, selections):
+    """Judge every question against the submitted selections in one pass.
+
+    Pure helper (no Streamlit, no mutation of its arguments). ``selections``
+    holds the widget values aligned with the question lists in ``quiz_data``:
+    ``single_choice`` -> option text or None, ``multiple_choice`` -> list of
+    checked option texts, ``true_false`` -> "True"/"False"/None,
+    ``short_answer`` -> raw text.
+
+    Returns ``(results, judgments)``: ``results`` is the quiz-results dict
+    stored for the profile update (per-type counts + wrong_questions), and
+    ``judgments`` maps each question's widget key to its verdict for
+    rendering and review-list updates. Short answers have no reliable
+    auto-scoring, so they count as answered only (``is_correct=None``) and
+    never reach the review list; unanswered questions are not counted.
+    """
+    quiz_data = quiz_data or {}
+    selections = selections or {}
+    results = new_quiz_results()
+    judgments = {}
+    number = 0
+
+    def pick(kind, index):
+        values = selections.get(kind) or []
+        return values[index] if index < len(values) else None
+
+    for i, q in enumerate(quiz_data.get("single_choice_questions") or []):
+        number += 1
+        selected = pick("single_choice", i)
+        correct_option = _resolve_correct_option(q["options"], q["correct_option"])
+        expected = correct_option if correct_option is not None else q["correct_option"]
+        answered = selected is not None
+        is_correct = (selected == correct_option) if answered else None
+        if answered:
+            record_quiz_answer(results, "single_choice", is_correct,
+                               question=q["question"], expected_answer=expected)
+        judgments[f"single_{i}"] = {
+            "number": number, "kind": "single_choice", "question": q["question"],
+            "answered": answered, "is_correct": is_correct,
+            "verdict": _quiz_verdict(answered, bool(is_correct)), "expected_answer": expected,
+        }
+
+    for i, q in enumerate(quiz_data.get("multiple_choice_questions") or []):
+        number += 1
+        selected = list(pick("multiple_choice", i) or [])
+        correct_options = [c for c in (_resolve_correct_option(q["options"], idx) for idx in q["correct_options"]) if c is not None]
+        answered = len(selected) > 0
+        is_correct = (set(selected) == set(correct_options)) if answered else None
+        if answered:
+            record_quiz_answer(results, "multiple_choice", is_correct,
+                               question=q["question"], expected_answer=correct_options)
+        judgments[f"multi_{i}"] = {
+            "number": number, "kind": "multiple_choice", "question": q["question"],
+            "answered": answered, "is_correct": is_correct,
+            "verdict": _quiz_verdict(answered, bool(is_correct)), "expected_answer": correct_options,
+        }
+
+    for i, q in enumerate(quiz_data.get("true_false_questions") or []):
+        number += 1
+        selected = pick("true_false", i)
+        correct_answer = "True" if q["correct_answer"] else "False"
+        answered = selected is not None
+        is_correct = (selected == correct_answer) if answered else None
+        if answered:
+            record_quiz_answer(results, "true_false", is_correct,
+                               question=q["question"], expected_answer=correct_answer)
+        judgments[f"tf_{i}"] = {
+            "number": number, "kind": "true_false", "question": q["question"],
+            "answered": answered, "is_correct": is_correct,
+            "verdict": _quiz_verdict(answered, bool(is_correct)), "expected_answer": correct_answer,
+        }
+
+    for i, q in enumerate(quiz_data.get("short_answer_questions") or []):
+        number += 1
+        user_answer = pick("short_answer", i) or ""
+        expected = q.get("expected_answer") or ""
+        answered = bool(user_answer.strip())
+        display_correct = user_answer.strip().lower() == expected.strip().lower()
+        if answered:
+            record_quiz_answer(results, "short_answer", None)
+        judgments[f"short_{i}"] = {
+            "number": number, "kind": "short_answer", "question": q["question"],
+            "answered": answered, "is_correct": None,
+            "verdict": _quiz_verdict(answered, display_correct), "expected_answer": expected,
+        }
+
+    return results, judgments
+
+
+def update_quiz_review_list(review_list, goal_id, wrong_entries, wrong_at):
+    """Merge freshly wrong questions into the per-goal review list.
+
+    Dedupes by question text within the goal: a question missed again bumps
+    ``times_seen`` and refreshes ``wrong_at`` instead of adding a second row.
+    Mutates and returns ``review_list`` ({goal_id: [entry, ...]}).
+    """
+    entries = review_list.setdefault(str(goal_id), [])
+    by_question = {entry.get("question"): entry for entry in entries}
+    for wrong in wrong_entries:
+        question = wrong.get("question") or ""
+        existing = by_question.get(question)
+        if existing is not None:
+            existing["times_seen"] = int(existing.get("times_seen", 1)) + 1
+            existing["wrong_at"] = wrong_at
+            if wrong.get("session_title"):
+                existing["session_title"] = wrong["session_title"]
+            if wrong.get("expected_answer") is not None:
+                existing["expected_answer"] = wrong["expected_answer"]
+        else:
+            entry = {
+                "session_title": wrong.get("session_title", ""),
+                "question": question,
+                "expected_answer": wrong.get("expected_answer"),
+                "wrong_at": wrong_at,
+                "times_seen": 1,
+            }
+            entries.append(entry)
+            by_question[question] = entry
+    return review_list
+
+
+def humanize_time_ago(epoch, now=None):
+    """Humanise a unix timestamp relative to ``now`` ("3 hours ago")."""
+    try:
+        epoch = float(epoch)
+    except (TypeError, ValueError):
+        return "at an unknown time"
+    now = time.time() if now is None else float(now)
+    seconds = max(0, int(now - epoch))
+    if seconds < 10:
+        return "just now"
+    if seconds < 60:
+        return f"{seconds} seconds ago"
+    minutes = seconds // 60
+    if minutes < 60:
+        return f"{minutes} minute{'s' if minutes != 1 else ''} ago"
+    hours = seconds // 3600
+    if hours < 24:
+        return f"{hours} hour{'s' if hours != 1 else ''} ago"
+    days = hours // 24
+    if days < 31:
+        return f"{days} day{'s' if days != 1 else ''} ago"
+    months = days // 31
+    if months < 12:
+        return f"{months} month{'s' if months != 1 else ''} ago"
+    years = days // 365
+    return f"{years} year{'s' if years != 1 else ''} ago"
+
+
 def resolve_session_title(session_information, learning_path, selected_session_id=0):
     if isinstance(session_information, dict) and session_information.get("title"):
         return session_information["title"]
@@ -567,94 +834,136 @@ def clear_quiz_results(session_uid):
     st.session_state.pop(quiz_results_state_key(session_uid), None)
 
 
+def record_wrong_questions_for_review(goal_id, session_title, judgments):
+    """Fold one submission's wrong questions into the per-goal review list.
+
+    Also mirrors the goal's entries into a ``quiz_results_review_{goal_id}``
+    session key after every update so the persistence layer (which picks up
+    any ``quiz_results_*`` key automatically) keeps the review list across
+    app restarts.
+    """
+    wrong_entries = [
+        {"session_title": session_title, "question": judgment["question"],
+         "expected_answer": judgment.get("expected_answer")}
+        for judgment in judgments.values()
+        if judgment.get("is_correct") is False
+    ]
+    if not wrong_entries:
+        return
+    if QUIZ_REVIEW_LIST_KEY not in st.session_state:
+        st.session_state[QUIZ_REVIEW_LIST_KEY] = {}
+    review_list = update_quiz_review_list(st.session_state[QUIZ_REVIEW_LIST_KEY], goal_id, wrong_entries, wrong_at=time.time())
+    st.session_state[quiz_review_state_key(goal_id)] = list(review_list.get(str(goal_id), []))
+    save_persistent_state()
+
+
+def render_quiz_judgments(judgments, quiz_data):
+    """Per-question verdicts and explanations after Submit Answers."""
+    st.divider()
+    for _kind, list_key, key_prefix in QUIZ_KIND_FIELDS:
+        for i, q in enumerate((quiz_data or {}).get(list_key) or []):
+            judgment = judgments.get(f"{key_prefix}{i}")
+            if judgment is None:
+                continue
+            st.write(f"**{judgment['number']}. {q['question']}**")
+            if judgment.get("verdict") == "correct":
+                st.success("Correct!")
+            elif judgment.get("verdict") == "incorrect":
+                st.error("Incorrect.")
+            else:
+                st.caption("Not answered.")
+            expected = format_expected_answer(judgment.get("expected_answer"))
+            with st.expander("Explanation", expanded=judgment.get("verdict") == "incorrect", icon=":material/info:"):
+                if judgment.get("verdict") == "incorrect" and expected:
+                    st.markdown(f"**Expected answer:** {expected}")
+                st.write(q.get("explanation", ""))
+
+
+def render_quiz_review_list(goal_id):
+    """Collapsed recap of the questions this goal still owes a correct answer."""
+    entries = (st.session_state.get(QUIZ_REVIEW_LIST_KEY) or {}).get(str(goal_id))
+    if not entries:
+        # Restart-safe fallback: the mirrored quiz_results_review_* key is the
+        # copy restored by the persistence layer.
+        entries = st.session_state.get(quiz_review_state_key(goal_id)) or []
+    if not entries:
+        return
+    count = len(entries)
+    with st.expander(f"🔖 Review later — {count} question{'s' if count != 1 else ''} to revisit", expanded=False):
+        st.caption("Questions answered incorrectly for this goal, most recent first.")
+        for entry in sorted(entries, key=lambda e: e.get("wrong_at") or 0, reverse=True):
+            times_seen = int(entry.get("times_seen", 1))
+            st.markdown(f"**{entry.get('question', '')}**")
+            st.caption(
+                f"Missed {times_seen} time{'s' if times_seen != 1 else ''} · "
+                f"last seen {humanize_time_ago(entry.get('wrong_at') or 0)} · "
+                f"{entry.get('session_title') or 'earlier session'}"
+            )
+            expected = format_expected_answer(entry.get("expected_answer"))
+            if expected:
+                st.markdown(f"Expected answer: {expected}")
+
+
 def render_questions(quiz_data):
     st.subheader("💡 Test Your Knowledge")
     session_uid = get_current_session_uid()
-    # Results are rebuilt from the widget values on every rerun so changing an
-    # answer keeps the summary in sync; only multiple-choice Submit results
-    # are latched (a bare button click does not survive reruns).
-    previous_results = st.session_state.get(quiz_results_state_key(session_uid)) or {}
-    submitted_multiple_choice = dict(previous_results.get(SUBMITTED_MULTIPLE_CHOICE_KEY, {}))
-    results = new_quiz_results()
+    goal_id = st.session_state["selected_goal_id"]
+    goal = st.session_state["goals"][goal_id]
+    session_title = resolve_session_title(None, goal.get("learning_path"),
+                                          st.session_state.get("selected_session_id", 0))
+
+    # Selections are made for every question first and judged together when
+    # "Submit Answers" is pressed; nothing is scored per interaction.
+    selections = {"single_choice": [], "multiple_choice": [], "true_false": [], "short_answer": []}
+    question_counts = {list_key: len(quiz_data.get(list_key) or []) for _kind, list_key, _prefix in QUIZ_KIND_FIELDS}
 
     for i, q in enumerate(quiz_data['single_choice_questions']):
-        st.write(f"**{i+1}. {q['question']}**")
-        selected_option = st.radio("Options", q['options'], key=f"single_{i}", index=None, label_visibility="hidden")
-        if selected_option is not None:
-            correct_option = _resolve_correct_option(q['options'], q['correct_option'])
-            is_correct = selected_option == correct_option
-            if is_correct:
-                st.success("Correct!")
-            else:
-                st.error("Incorrect.")
-            record_quiz_answer(results, "single_choice", is_correct,
-                               question=q['question'],
-                               expected_answer=correct_option if correct_option is not None else q['correct_option'])
-            with st.expander("Explanation", expanded=True, icon=":material/info:"):
-                st.write(q['explanation'])
+        st.write(f"**{i + 1}. {q['question']}**")
+        selections["single_choice"].append(
+            st.radio("Options", q['options'], key=f"single_{i}", index=None, label_visibility="hidden"))
 
     for i, q in enumerate(quiz_data['multiple_choice_questions']):
-        st.write(f"**{len(quiz_data['single_choice_questions']) + i + 1}. {q['question']}**")
-
-        selected_options = []
-        for j, option in enumerate(q['options']):
-            if st.checkbox(option, key=f"multi_{i}_option_{j}"):
-                selected_options.append(option)
-
-        correct_options = [c for c in (_resolve_correct_option(q['options'], idx) for idx in q['correct_options']) if c is not None]
-
-        if st.button("Submit", key=f"multi_submit_{i}"):
-            submitted_multiple_choice[i] = set(selected_options) == set(correct_options)
-            if submitted_multiple_choice[i]:
-                st.success("Correct!")
-            else:
-                st.error("Some options are incorrect.")
-            with st.expander("Explanation", expanded=False):
-                st.write(q['explanation'])
-
-        if i in submitted_multiple_choice:
-            record_quiz_answer(results, "multiple_choice", submitted_multiple_choice[i],
-                               question=q['question'], expected_answer=correct_options)
+        st.write(f"**{question_counts['single_choice_questions'] + i + 1}. {q['question']}**")
+        selections["multiple_choice"].append([
+            option for j, option in enumerate(q['options'])
+            if st.checkbox(option, key=f"multi_{i}_option_{j}")
+        ])
 
     for i, q in enumerate(quiz_data['true_false_questions']):
-        st.write(f"**{len(quiz_data['single_choice_questions']) + len(quiz_data['multiple_choice_questions']) + i + 1}. {q['question']}**")
-        selected_answer = st.radio("True or False?", ["True", "False"], key=f"tf_{i}", label_visibility="hidden", index=None)
-        correct_answer = "True" if q['correct_answer'] else "False"
-        if selected_answer:
-            is_correct = selected_answer == correct_answer
-            if is_correct:
-                st.success("Correct!")
-            else:
-                st.error("Incorrect.")
-            record_quiz_answer(results, "true_false", is_correct,
-                               question=q['question'], expected_answer=correct_answer)
-            with st.expander("Explanation", expanded=False):
-                st.write(q['explanation'])
+        st.write(f"**{question_counts['single_choice_questions'] + question_counts['multiple_choice_questions'] + i + 1}. {q['question']}**")
+        selections["true_false"].append(
+            st.radio("True or False?", ["True", "False"], key=f"tf_{i}", label_visibility="hidden", index=None))
 
     for i, q in enumerate(quiz_data['short_answer_questions']):
-        st.write(f"**{len(quiz_data['single_choice_questions']) + len(quiz_data['multiple_choice_questions']) + len(quiz_data['true_false_questions']) + i + 1}. {q['question']}**")
-        user_answer = st.text_input("Your Answer", key=f"short_{i}", label_visibility="hidden")
-        if user_answer:
-            if user_answer.strip().lower() == q['expected_answer'].strip().lower():
-                st.success("Correct!")
-            else:
-                st.error("Incorrect.")
-            # No reliable auto-scoring for short answers: count as answered only.
-            record_quiz_answer(results, "short_answer", None)
-            with st.expander("Explanation", expanded=False):
-                st.write(q['explanation'])
+        st.write(f"**{question_counts['single_choice_questions'] + question_counts['multiple_choice_questions'] + question_counts['true_false_questions'] + i + 1}. {q['question']}**")
+        selections["short_answer"].append(
+            st.text_input("Your Answer", key=f"short_{i}", label_visibility="hidden"))
 
-    results[SUBMITTED_MULTIPLE_CHOICE_KEY] = submitted_multiple_choice
-    st.session_state[quiz_results_state_key(session_uid)] = results
+    if st.button("Submit Answers", key="submit-all-answers", type="primary",
+                 icon=":material/fact_check:", use_container_width=True):
+        # Judge everything at once and latch the outcome (a bare button click
+        # does not survive reruns) so the summary is already stored before the
+        # Complete Session profile update reads it.
+        results, judgments = judge_quiz_submissions(quiz_data, selections)
+        results[SUBMITTED_ANSWERS_KEY] = judgments
+        st.session_state[quiz_results_state_key(session_uid)] = results
+        record_wrong_questions_for_review(goal_id, session_title, judgments)
+        save_persistent_state()
 
-    summary = summarize_quiz_results(results)
-    if summary["total_answered"] > 0:
-        col1, col2, col3 = st.columns(3)
-        col1.metric("Answered", summary["total_answered"])
-        col2.metric("Correct", summary["total_correct"])
-        col3.metric("Accuracy", f"{summary['accuracy']:.0%}")
+    stored_results = st.session_state.get(quiz_results_state_key(session_uid)) or {}
+    judgments = stored_results.get(SUBMITTED_ANSWERS_KEY) or {}
+    if judgments:
+        render_quiz_judgments(judgments, quiz_data)
+        summary = summarize_quiz_results(stored_results)
+        if summary["total_answered"] > 0:
+            col1, col2, col3 = st.columns(3)
+            col1.metric("Answered", summary["total_answered"])
+            col2.metric("Correct", summary["total_correct"])
+            col3.metric("Accuracy", f"{summary['accuracy']:.0%}")
 
-    return results
+    render_quiz_review_list(goal_id)
+
+    return stored_results
 
 def render_content_feedback_form(goal):
     st.header("🌟 Value Your Feedback!") 

--- a/frontend/views/learning_path.py
+++ b/frontend/views/learning_path.py
@@ -30,8 +30,18 @@ def render_learning_path():
         </style>
     """, unsafe_allow_html=True)
     if not goal["learning_path"]:
+        st.info("Pick how many sessions this goal should be split into. Scheduling starts right away; if it fails, adjust the number and it retries.")
+        session_count = st.number_input(
+            "Number of sessions",
+            min_value=3,
+            max_value=10,
+            value=8,
+            step=1,
+            help="Total learning sessions for the first schedule of this goal (3-10).",
+            key="initial_session_count",
+        )
         with st.spinner('Scheduling Learning Path ...'):
-            scheduled = schedule_learning_path(goal["learner_profile"], session_count=8, llm_type=st.session_state["llm_type"])
+            scheduled = schedule_learning_path(goal["learner_profile"], session_count=int(session_count), llm_type=st.session_state["llm_type"])
         if scheduled is None:
             # Backend failed (message already shown by the client); keep the
             # empty path so the next render retries instead of treating the

--- a/frontend/views/sources.py
+++ b/frontend/views/sources.py
@@ -1,0 +1,203 @@
+"""Knowledge Sources view: the web pages pinned into the current goal's knowledge base.
+
+The backend saves pages it reads while generating learning content; this view
+lists them, summarises the corpus, and lets the learner unpin a page so the
+tutor no longer draws on it.
+"""
+
+import html
+import time
+
+import streamlit as st
+
+from utils.request_api import kb_sources, kb_unpin
+
+
+# --- Pure helpers -------------------------------------------------------------
+# No streamlit access here, so these stay importable and testable on a bare
+# interpreter. Every one of them tolerates a drifted payload shape.
+
+
+def _field(source, key, default=""):
+    """Read ``key`` off a source entry without trusting the payload shape."""
+    if not isinstance(source, dict):
+        return default
+    value = source.get(key, default)
+    return default if value is None else value
+
+
+def _relative(count, unit):
+    """``3 days``-style span, pluralised (no trailing ``ago``)."""
+    return f"{count} {unit}{'' if count == 1 else 's'}"
+
+
+def _humanize_age(epoch, now=None):
+    """Render an epoch-seconds timestamp as a short relative age.
+
+    Missing/zero/future timestamps yield ``"unknown"`` — there is nothing
+    truthful to claim about them. ``now`` is injectable for tests.
+    """
+
+    def ago(count, unit):
+        return f"{_relative(count, unit)} ago"
+
+    if not epoch:
+        return "unknown"
+    try:
+        age_seconds = int((time.time() if now is None else float(now)) - float(epoch))
+    except (TypeError, ValueError):
+        return "unknown"
+    if age_seconds < 0:
+        return "unknown"
+    if age_seconds < 10:
+        return "just now"
+    if age_seconds < 60:
+        return ago(age_seconds, "second")
+    minutes = age_seconds // 60
+    if minutes < 60:
+        return ago(minutes, "minute")
+    hours = minutes // 60
+    if hours < 24:
+        return ago(hours, "hour")
+    days = hours // 24
+    if days < 7:
+        return ago(days, "day")
+    if days < 30:
+        return ago(days // 7, "week")
+    if days < 365:
+        return ago(days // 30, "month")
+    return ago(days // 365, "year")
+
+
+def _pinned_label(epoch):
+    """Card-friendly phrasing of a ``pinned_at`` value."""
+    age = _humanize_age(epoch)
+    return "Pin time unknown" if age == "unknown" else f"Pinned {age}"
+
+
+def _chunk_count(source):
+    """Number of stored chunks, or 0 when the field is missing or malformed."""
+    chunk_ids = _field(source, "chunk_ids", [])
+    if not isinstance(chunk_ids, (list, tuple)):
+        return 0
+    return len(chunk_ids)
+
+
+def _chunk_label(source):
+    return _relative(_chunk_count(source), "chunk")
+
+
+def _display_title(source):
+    """The page title, falling back to the url, then to a placeholder."""
+    url = str(_field(source, "source")).strip()
+    title = str(_field(source, "title")).strip()
+    return title or url or "Untitled page"
+
+
+def _title_link_html(source):
+    """Anchor markup for the card title; opens in a new tab.
+
+    Falls back to plain text when the entry has no usable url.
+    """
+    title = html.escape(_display_title(source))
+    url = str(_field(source, "source")).strip()
+    if not url:
+        return f"<span>{title}</span>"
+    return (
+        f'<a href="{html.escape(url, quote=True)}" target="_blank" '
+        f'rel="noopener noreferrer">{title}</a>'
+    )
+
+
+def _source_caption(source):
+    """The small meta line under a card title: url · pinned when · chunk count."""
+    parts = [
+        str(_field(source, "source")).strip(),
+        _pinned_label(_field(source, "pinned_at", 0)),
+        _chunk_label(source),
+    ]
+    return " · ".join(part for part in parts if part)
+
+
+def _shorten(text, limit=60):
+    """Truncate long titles for toasts without cutting mid-word spacing."""
+    text = str(text)
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def _normalize_sources(raw):
+    """Keep only dict entries so a drifted payload cannot crash the render."""
+    if not isinstance(raw, list):
+        return []
+    return [entry for entry in raw if isinstance(entry, dict)]
+
+
+# --- Rendering ----------------------------------------------------------------
+
+
+def render_sources():
+    if not st.session_state.get("if_complete_onboarding"):
+        st.switch_page("views/onboarding.py")
+
+    goal = st.session_state["goals"][st.session_state["selected_goal_id"]]
+    goal_id = goal.get("id", "")
+
+    st.title("Knowledge Sources")
+    st.write("Pages the system saved while generating this goal's learning content — the tutor draws on them when answering.")
+
+    sources = _normalize_sources(kb_sources(goal_id))
+    total_chunks = sum(_chunk_count(source) for source in sources)
+
+    pages_col, chunks_col, refresh_col = st.columns([2, 2, 1])
+    pages_col.metric("Total pages", len(sources))
+    chunks_col.metric("Total chunks", total_chunks)
+    with refresh_col:
+        st.write("")  # nudge the button towards the metric baseline
+        if st.button("Refresh", icon=":material/refresh:", use_container_width=True):
+            # Data changes as the user studies in another tab; pull it again.
+            st.rerun()
+
+    if not sources:
+        st.info(
+            "No pages saved for this goal yet. The knowledge base fills in automatically as "
+            "learning documents are generated — learn a session from the Learning Path page, or "
+            "regenerate a knowledge point's content, and the pages the system reads along the "
+            "way will appear here."
+        )
+        return
+
+    st.markdown("#### 📚 Saved Pages")
+    for index, source in enumerate(sources):
+        _render_source_card(goal_id, source, index)
+
+
+def _render_source_card(goal_id, source, index):
+    url = str(_field(source, "source")).strip()
+    title = _display_title(source)
+
+    with st.container(border=True):
+        text_col, action_col = st.columns([6, 1])
+        with text_col:
+            st.markdown(_title_link_html(source), unsafe_allow_html=True)
+            st.caption(_source_caption(source))
+        with action_col:
+            with st.popover("Unpin", icon=":material/delete:", use_container_width=True):
+                st.caption(f"Remove {_shorten(title)} from this goal's knowledge base? The tutor will no longer draw on it.")
+                if st.button("Confirm unpin", key=f"unpin_confirm_{index}", use_container_width=True, type="primary"):
+                    _unpin_source(goal_id, url, title)
+
+
+def _unpin_source(goal_id, url, title):
+    if not url:
+        st.warning("This source has no URL, so it cannot be unpinned.")
+        return
+    if kb_unpin(goal_id, url):
+        st.toast(f"Unpinned {_shorten(title)}.", icon=":material/check_circle:")
+        st.rerun()
+    # On failure the client already showed the error; keep the card so the
+    # user can retry.
+
+
+render_sources()


### PR DESCRIPTION
## Summary

Roadmap items 8–12: frontend experience round plus the data-layer upgrade.

### Knowledge Sources page (#9)
The per-goal knowledge base is now visible: cards with linked title, url, humanized pin age and chunk counts; popover-confirmed unpin backed by new `GET/DELETE /knowledge-base/{goal_id}` endpoints (precise single-page removal).

### Quiz interaction (#10)
- Unified **Submit Answers** judging replaces instant per-question verdicts; explanations reveal on submit (auto-expanded for wrong answers)
- Wrong questions feed a per-goal **Review later** list (deduped by question, `times_seen` bumped on repeat misses) — the seed for spaced repetition
- Quiz results now persist (auto-captured `quiz_results_*` keys): completing a session after an app restart keeps the answers

### Pipeline auto-refresh (#8)
A display-only `@st.fragment(run_every="5s")` shows a stage progress bar ("Stage 2/4 ✓ restored…") while content generation runs; heavy work stays outside the fragment and it self-terminates on completion.

### Session count in the UI (#11)
First-time path scheduling exposes "Number of sessions" (3–10) instead of the hardcoded 8.

### SQLite persistence (#12)
`user_data/data_store.json` → WAL SQLite (`data_store.db`): goals/blobs/mastery_history/kv tables with per-key upserts (concurrent tabs become last-write-wins per key instead of whole-file clobbering). Legacy stores auto-migrate with a `.migrated` backup; `state.py` keeps its public API so all call sites are untouched. Mastery history now carries real timestamps and the dashboard plots against them.

## Verification
- backend 81+1 / frontend 13 suites green; full project compiles
- New: sources-page helpers 46 checks, quiz+pipeline pure-logic harness 96 checks, SQLite round-trip + legacy migration + 4-thread concurrent-write test
- Live: KB pin/list/unpin end-to-end; real user data migrated intact (2 goals, caches, history)