### PR TITLE
Section kickers, hero stat strip, pill tabs, micro details

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,6 +275,22 @@
           paths to
           meet individual goals with precision.
         </h2>
+        <div class="hero-stats">
+          <div class="hero-stat">
+            <span class="stat-value">0.67</span>
+            <span class="stat-label">Goal-to-skill recall &mdash; +59% over the best prompt baseline</span>
+          </div>
+          <span class="stat-divider" aria-hidden="true"></span>
+          <div class="hero-stat">
+            <span class="stat-value">4.71<span class="stat-unit">/5</span></span>
+            <span class="stat-label">Learning-path engagement in evaluation</span>
+          </div>
+          <span class="stat-divider" aria-hidden="true"></span>
+          <div class="hero-stat">
+            <span class="stat-value">3</span>
+            <span class="stat-label">Adaptive agents for personalized tutoring</span>
+          </div>
+        </div>
       </div>
     </div>
   </section>
@@ -322,6 +338,7 @@
     <div class="container is-max-desktop">
       <div class="columns is-centered has-text-centered">
         <div class="column is-four-fifths">
+          <p class="section-kicker">01 · Overview</p>
           <h2 class="title is-3">Abstract</h2>
           <div class="content has-text-justified">
             <p>
@@ -330,12 +347,14 @@
               However, as goal-oriented learning, which emphasizes efficiently achieving specific objectives, becomes
               increasingly important in professional contexts, existing ITSs often struggle to deliver this type of
               targeted learning experience.
-              In this paper, we propose GenMentor, an LLM-powered multi-agent framework designed to deliver
+              In this paper, we propose <strong>GenMentor, an LLM-powered multi-agent framework</strong> designed to
+              deliver
               goal-oriented, personalized learning within ITS. GenMentor begins by accurately mapping learners' goals to
               required skills using a fine-tuned LLM trained on a custom goal-to-skill dataset.
               After identifying the skill gap, it schedules an efficient learning path using an evolving optimization
               approach, driven by a comprehensive and dynamic profile of learners' multifaceted status.
-              Additionally, GenMentor tailors learning content with an exploration-drafting-integration mechanism to
+              Additionally, GenMentor tailors learning content with an
+              <strong>exploration-drafting-integration mechanism</strong> to
               align with individual learner needs. Extensive automated and human evaluations demonstrate GenMentor's
               effectiveness in learning guidance and content quality.
               Furthermore, we have deployed it in practice and also implemented it as an application. Practical human
@@ -353,7 +372,10 @@
     <div class="hero-body">
       <div class="container">
         <div class="columns is-centered has-text-centered">
-          <h2 class="title is-3">Goal-oriented Learning</h2>
+          <div class="column is-12">
+            <p class="section-kicker">02 · Motivation</p>
+            <h2 class="title is-3">Goal-oriented Learning</h2>
+          </div>
         </div>
 
         <!-- Motivation Cards -->
@@ -435,7 +457,10 @@
   <section class="hero-body is-light" id="framework">
     <div class="container">
       <div class="columns is-centered">
-        <h2 class="title is-3 has-text-centered">GenMentor Framework</h2>
+        <div class="column is-12">
+          <p class="section-kicker">03 · Architecture</p>
+          <h2 class="title is-3 has-text-centered">GenMentor Framework</h2>
+        </div>
       </div>
 
       <!-- Framework Overview -->
@@ -654,7 +679,10 @@
     <div class="hero-body">
       <div class="container">
         <div class="columns is-centered has-text-centered">
-          <h2 class="title is-3">Experimental Results</h2>
+          <div class="column is-12">
+            <p class="section-kicker">04 · Evaluation</p>
+            <h2 class="title is-3">Experimental Results</h2>
+          </div>
         </div>
 
         <!-- Detailed Results -->
@@ -756,7 +784,10 @@
     <div class="hero-body">
       <div class="container">
         <div class="columns is-centered has-text-centered">
-          <h2 class="title is-3">Demo Video Presentation</h2>
+          <div class="column is-12">
+            <p class="section-kicker">05 · Demo</p>
+            <h2 class="title is-3">Demo Video Presentation</h2>
+          </div>
         </div>
         <div class="columns is-centered has-text-centered mb-5">
           <div class="column is-three-fifths">
@@ -784,6 +815,7 @@
 
   <section class="section" id="BibTeX">
     <div class="container is-max-desktop content has-text-centered">
+      <p class="section-kicker">06 · Citation</p>
       <h2 class="title">BibTeX</h2>
       <div class="bibtex-box">
         <button class="button is-small bibtex-copy" id="bibtex-copy" type="button" aria-label="Copy BibTeX entry">

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1339,3 +1339,176 @@ html[data-theme='dark'] .slider-pagination .slider-page {
 html[data-theme='dark'] .slider-pagination .slider-page.is-active {
   background-color: hsl(204, 86%, 63%);
 }
+
+/* ---------- Visual polish: kickers, hero stats, pill tabs,
+   selection & scrollbar details ---------- */
+
+/* Section eyebrow labels */
+.section-kicker {
+  display: block;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: hsl(204, 86%, 45%);
+  margin-bottom: 0.4rem !important;
+}
+
+html[data-theme='dark'] .section-kicker {
+  color: hsl(204, 86%, 68%);
+}
+
+/* Hero stat strip */
+.hero-stats {
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  gap: 2.25rem;
+  margin-top: 2.25rem;
+}
+
+.hero-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  max-width: 15rem;
+}
+
+.stat-value {
+  font-size: 1.9rem;
+  font-weight: 800;
+  line-height: 1.1;
+  color: #363636;
+  font-variant-numeric: tabular-nums;
+}
+
+.stat-unit {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #7a7a7a;
+}
+
+.stat-label {
+  font-size: 0.8rem;
+  color: #7a7a7a;
+  line-height: 1.35;
+  text-align: center;
+}
+
+.stat-divider {
+  width: 1px;
+  background: #dbdbdb;
+}
+
+html[data-theme='dark'] .stat-value {
+  color: #e8e9ea;
+}
+
+html[data-theme='dark'] .stat-unit,
+html[data-theme='dark'] .stat-label {
+  color: #9a9da6;
+}
+
+html[data-theme='dark'] .stat-divider {
+  background: #2b2d34;
+}
+
+@media screen and (max-width: 768px) {
+  .hero-stats {
+    flex-direction: column;
+    gap: 1.25rem;
+    align-items: center;
+  }
+
+  .stat-divider {
+    display: none;
+  }
+}
+
+/* Framework tabs: pill style, matching the results tabs */
+#arch-tabs {
+  border-bottom: none;
+  margin-bottom: 1.5rem;
+}
+
+#arch-tabs ul {
+  border-bottom: none;
+  gap: 0.6rem;
+}
+
+#arch-tabs li a {
+  border: 1px solid #dbdbdb;
+  border-radius: 8px;
+  background-color: #ffffff;
+  padding: 0.55rem 1.4rem;
+  transition: all 0.25s ease;
+}
+
+#arch-tabs li a:hover {
+  background-color: rgba(72, 157, 246, 0.08);
+  border-color: hsl(204, 86%, 53%);
+  color: hsl(204, 86%, 45%);
+}
+
+#arch-tabs li.is-active a {
+  background-color: hsl(204, 86%, 47%);
+  border-color: hsl(204, 86%, 47%);
+  color: #ffffff !important;
+}
+
+html[data-theme='dark'] #arch-tabs li a {
+  background-color: #17181c;
+  border-color: #2b2d34;
+  color: #dbdbdb;
+}
+
+html[data-theme='dark'] #arch-tabs li a:hover {
+  background-color: rgba(102, 157, 246, 0.10);
+  border-color: hsl(204, 86%, 63%);
+  color: hsl(204, 86%, 68%);
+}
+
+/* Selection and scrollbar details */
+::selection {
+  background: hsl(204, 86%, 53%);
+  color: #ffffff;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #c3c5cb;
+  border-radius: 6px;
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #9a9da6;
+  background-clip: content-box;
+}
+
+html[data-theme='dark'] ::-webkit-scrollbar-thumb {
+  background: #3a3d45;
+  background-clip: content-box;
+}
+
+html[data-theme='dark'] ::-webkit-scrollbar-thumb:hover {
+  background: #4a4e58;
+  background-clip: content-box;
+}
+
+/* A kicker inserted directly inside a Bulma .columns flex row (where the
+   section title is not wrapped in its own .column) must take a full
+   flex row, or it sits beside the title. */
+.columns > .section-kicker {
+  flex-basis: 100%;
+}


### PR DESCRIPTION
Third visual polish pass.

## Section kickers
Numbered eyebrow labels above every section title (`01 · OVERVIEW` … `06 · CITATION`) — small, uppercase, letter-spaced accent blue — giving the page a consistent editorial rhythm. The four section titles that sat directly inside a Bulma `.columns` (which is `nowrap` flex in this Bulma version) are wrapped in a `.column.is-12` so the kicker renders as its own centered row (first attempt without the wrapper put the kicker beside the title — caught in screenshot review).

## Hero stat strip
A three-stat band under the hero tagline, using figures already present on the page (evaluation tables + framework section): **0.67** goal-to-skill recall (+59% over the best prompt baseline), **4.71/5** learning-path engagement, **3** adaptive agents. Dividers collapse on mobile.

## Framework tabs
Boxed tabs restyled as the same pill treatment the results tabs use (rounded, bordered, blue active).

## Micro details
- the two key contribution phrases in the abstract are emphasized (breaks the wall of justified text)
- accent-blue `::selection`
- slim, theme-aware custom scrollbars

## Verified locally
Desktop light + dark and 390px mobile; kicker alignment, stat strip wrapping, tab states, scrollspy interplay all screenshot-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)