### PR TITLE
feat: move the state store to the backend (per-user, KB cascade, wipe guards)

### DIFF
--- a/backend/api_schemas.py
+++ b/backend/api_schemas.py
@@ -166,8 +166,16 @@ class TailoredContentGenerationRequest(BaseRequest):
     goal_id: Optional[str] = None  # pins search results into the goal's knowledge base
 
 
+class StateSnapshotRequest(BaseRequest):
+    """A full session-state snapshot pushed by a frontend client."""
+
+    user_id: str = "TestUser"
+    snapshot: JsonLike = Field(default_factory=dict)
+
+
 __all__ = [
     "JsonLike",
+    "StateSnapshotRequest",
     "BaseRequest",
     "ChatWithTutorRequest",
     "ChatWithAutorRequest",

--- a/backend/base/search_rag.py
+++ b/backend/base/search_rag.py
@@ -318,6 +318,20 @@ class SearchRagManager:
         logger.info("Unpinned %d KB chunks for goal %s", len(ids), goal_id)
         return len(ids)
 
+    def unpin_goal(self, goal_id: str) -> int:
+        """Drop a goal's entire knowledge base (called when the goal is deleted)."""
+        if self.kb_vectorstore is None:
+            return 0
+        fetched = self.kb_vectorstore._collection.get(
+            where={KB_GOAL_KEY: str(goal_id)}, include=[]
+        )
+        ids = fetched.get("ids") or []
+        if not ids:
+            return 0
+        self.kb_vectorstore._collection.delete(ids=ids)
+        logger.info("Cascade-unpinned %d KB chunks for deleted goal %s", len(ids), goal_id)
+        return len(ids)
+
     def prune_kb(self, goal_id: str) -> int:
         """Cap a goal's KB at kb_max_chunks_per_goal, evicting oldest first."""
         if self.kb_vectorstore is None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -198,6 +198,60 @@ def chat_with_tutor_stream(request: ChatWithTutorRequest):  # noqa: F405
     return StreamingResponse(generate(), media_type="text/plain; charset=utf-8")
 
 
+@app.get("/state")
+async def get_state(user_id: str = "TestUser"):
+    """Return the user's full persisted session-state snapshot."""
+    from utils import state_store
+
+    return {"user_id": user_id, "snapshot": state_store.load_snapshot(user_id)}
+
+
+@app.put("/state")
+async def put_state(request: StateSnapshotRequest):  # noqa: F405
+    """Persist a full session-state snapshot for the user.
+
+    Goals that disappeared (or were soft-deleted) since the previous snapshot
+    are cascaded out of the knowledge base.
+    """
+    from utils import state_store
+
+    if not isinstance(request.snapshot, dict):
+        # Treating a malformed payload as "empty" would wipe the user's whole
+        # server-side state (and cascade their knowledge base away).
+        raise HTTPException(status_code=400, detail="`snapshot` must be a JSON object.")
+    ok, removed_goals = state_store.save_snapshot(request.user_id, request.snapshot)
+    if not ok:
+        raise HTTPException(status_code=500, detail="Could not persist state.")
+    unpinned = 0
+    if removed_goals:
+        manager = get_search_rag_manager()
+        if manager is not None:
+            for gid in removed_goals:
+                unpinned += manager.unpin_goal(str(gid))
+    return {"user_id": request.user_id, "saved": True,
+            "cascaded_goals": sorted(removed_goals), "unpinned_chunks": unpinned}
+
+
+@app.delete("/state/{user_id}")
+async def reset_state(user_id: str):
+    """Archive then wipe the user's state (the frontend Reset flow).
+
+    The user's goals are collected before the wipe so their knowledge bases
+    can be cascade-unpinned afterwards.
+    """
+    from utils import state_store
+
+    goal_ids = state_store.goal_ids_for_user(user_id)
+    if not state_store.reset_user(user_id):
+        raise HTTPException(status_code=500, detail="Could not reset state.")
+    unpinned = 0
+    manager = get_search_rag_manager()
+    if manager is not None:
+        for gid in goal_ids:
+            unpinned += manager.unpin_goal(str(gid))
+    return {"user_id": user_id, "reset": True, "unpinned_chunks": unpinned}
+
+
 @app.get("/knowledge-base/{goal_id}")
 async def knowledge_base(goal_id: str):
     """List the pages pinned into a goal's knowledge base (newest first)."""

--- a/backend/tests/test_state_store.py
+++ b/backend/tests/test_state_store.py
@@ -1,0 +1,112 @@
+"""Tests for the server-owned state store and its /state endpoints."""
+
+import pytest
+
+
+@pytest.fixture()
+def state_db(tmp_path, monkeypatch):
+    """Point the store at a temp db for the duration of a test."""
+    monkeypatch.setenv("GENMENTOR_STATE_DB", str(tmp_path / "state.db"))
+    from utils import state_store
+
+    state_store.DEFAULT_DB_PATH = tmp_path / "state.db"
+    return state_store
+
+
+@pytest.fixture()
+def client(state_db, monkeypatch):
+    """TestClient with the RAG manager stubbed out (no model load)."""
+    import main
+
+    calls = {"unpinned": []}
+    fake_manager = type(
+        "M", (), {"unpin_goal": staticmethod(lambda gid: calls["unpinned"].append(gid) or 1)}
+    )()
+    monkeypatch.setattr(main, "get_search_rag_manager", lambda: fake_manager)
+    from fastapi.testclient import TestClient
+
+    return TestClient(main.app), calls
+
+
+SNAP = {
+    "goals": [
+        {"id": 0, "learning_goal": "a", "is_deleted": False},
+        {"id": 1, "learning_goal": "b", "is_deleted": False},
+    ],
+    "llm_type": "m1",
+    "document_caches": {"0-1": {"document": "# x"}},
+    "learned_skills_history": {"0": [{"ts": 1.0, "rate": 0.5}]},
+    "quiz_results_0-1": {"single_choice": {"answered": 1, "correct": 1}},
+}
+
+
+def test_round_trip_all_shapes(client):
+    c, _ = client
+    r = c.put("/state", json={"user_id": "u", "snapshot": SNAP})
+    assert r.status_code == 200
+    snap = c.get("/state", params={"user_id": "u"}).json()["snapshot"]
+    assert [g["id"] for g in snap["goals"]] == [0, 1]
+    assert snap["llm_type"] == "m1"
+    assert snap["document_caches"]["0-1"]["document"] == "# x"
+    assert snap["quiz_results_0-1"]["single_choice"]["correct"] == 1
+    assert snap["learned_skills_history"]["0"] == [{"ts": 1.0, "rate": 0.5}]
+
+
+def test_users_are_isolated(client):
+    c, _ = client
+    c.put("/state", json={"user_id": "u1", "snapshot": SNAP})
+    c.put("/state", json={"user_id": "u2", "snapshot": {"goals": [], "llm_type": "other"}})
+    assert c.get("/state", params={"user_id": "u1"}).json()["snapshot"]["llm_type"] == "m1"
+    assert c.get("/state", params={"user_id": "u2"}).json()["snapshot"]["llm_type"] == "other"
+
+
+def test_non_dict_snapshot_is_rejected_not_treated_as_empty(client):
+    """A malformed payload must never wipe the stored state."""
+    c, _ = client
+    c.put("/state", json={"user_id": "u", "snapshot": SNAP})
+    r = c.put("/state", json={"user_id": "u", "snapshot": ["not", "a", "dict"]})
+    assert r.status_code == 400
+    # stored data untouched
+    assert c.get("/state", params={"user_id": "u"}).json()["snapshot"]["goals"]
+
+
+def test_goal_removal_cascades_into_knowledge_base(client):
+    c, calls = client
+    c.put("/state", json={"user_id": "u", "snapshot": SNAP})
+    r = c.put("/state", json={"user_id": "u", "snapshot": {
+        **SNAP, "goals": [{"id": 0, "learning_goal": "a", "is_deleted": False}]}})
+    assert r.status_code == 200
+    assert set(r.json()["cascaded_goals"]) == {1}
+    assert calls["unpinned"] == ["1"]  # unpin_goal takes str goal ids
+
+
+def test_soft_deleted_goal_cascades(client):
+    c, calls = client
+    c.put("/state", json={"user_id": "u", "snapshot": SNAP})
+    r = c.put("/state", json={"user_id": "u", "snapshot": {
+        **SNAP, "goals": [{**SNAP["goals"][0], "is_deleted": True}, SNAP["goals"][1]]}})
+    assert set(r.json()["cascaded_goals"]) == {0}
+
+
+def test_reset_archives_then_wipes(client):
+    c, _ = client
+    import sqlite3
+
+    from utils import state_store
+
+    c.put("/state", json={"user_id": "u", "snapshot": SNAP})
+    assert c.delete("/state/u").status_code == 200
+    snap = c.get("/state", params={"user_id": "u"}).json()["snapshot"]
+    assert snap.get("goals", []) == [] and "llm_type" not in snap
+    conn = sqlite3.connect(state_store.db_path())
+    backups = conn.execute("SELECT COUNT(*) FROM state_backups WHERE user_id='u'").fetchone()[0]
+    conn.close()
+    assert backups == 1
+
+
+def test_store_goal_ids_survive_reset_collection(client):
+    """/state/{uid} reset collects ids BEFORE wiping so KB cascade can run."""
+    c, calls = client
+    c.put("/state", json={"user_id": "u", "snapshot": SNAP})
+    c.delete("/state/u")
+    assert sorted(calls["unpinned"]) == ["0", "1"]  # str goal ids

--- a/backend/utils/state_store.py
+++ b/backend/utils/state_store.py
@@ -1,0 +1,281 @@
+"""Server-owned persistence for frontend session state.
+
+The store moved to the backend so the data follows the service, not the UI
+process: every table is keyed by user_id, the frontend keeps only a
+session_state cache, and goal removal can cascade into the knowledge base.
+
+Snapshot shape (identical to what the frontend holds in session_state):
+    goals                    -> goals(user_id, id, data)
+    learned_skills_history   -> mastery_history(user_id, goal_id, ts, rate)
+    document_caches /        -> blobs(user_id, kind, uid, data)
+    content_pipeline_state /
+    session_learning_times
+    quiz_results_* (any key starting with that prefix)
+    everything else          -> kv(user_id, key, value)
+
+SQLite with WAL: the frontend saves whole snapshots on most interactions, so
+per-key upserts (rather than a single JSON blob row) keep concurrent users
+from clobbering each other.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS kv (
+    user_id TEXT NOT NULL,
+    key TEXT NOT NULL,
+    value TEXT NOT NULL,
+    PRIMARY KEY (user_id, key)
+);
+CREATE TABLE IF NOT EXISTS goals (
+    user_id TEXT NOT NULL,
+    id INTEGER NOT NULL,
+    data TEXT NOT NULL,
+    PRIMARY KEY (user_id, id)
+);
+CREATE TABLE IF NOT EXISTS blobs (
+    user_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    uid TEXT NOT NULL,
+    data TEXT NOT NULL,
+    PRIMARY KEY (user_id, kind, uid)
+);
+CREATE TABLE IF NOT EXISTS mastery_history (
+    user_id TEXT NOT NULL,
+    goal_id INTEGER NOT NULL,
+    ts REAL NOT NULL,
+    rate REAL NOT NULL,
+    PRIMARY KEY (user_id, goal_id, ts)
+);
+CREATE TABLE IF NOT EXISTS state_backups (
+    user_id TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    snapshot TEXT NOT NULL,
+    PRIMARY KEY (user_id, created_at)
+);
+"""
+
+# Top-level snapshot keys whose value is a {uid: blob} mapping.
+_DICT_OF_BLOBS = {"document_caches", "content_pipeline_state", "session_learning_times"}
+_QUIZ_PREFIX = "quiz_results_"
+
+DEFAULT_DB_PATH = Path(__file__).resolve().parents[1] / "data" / "genmentor_state.db"
+
+
+def db_path() -> Path:
+    """The store location; overridable via GENMENTOR_STATE_DB for deployments."""
+    return Path(os.getenv("GENMENTOR_STATE_DB", DEFAULT_DB_PATH))
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, timeout=5.0)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=3000")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    return conn
+
+
+def _dump(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _load(value: str) -> Any:
+    return json.loads(value)
+
+
+def save_snapshot(user_id: str, snapshot: Dict[str, Any]) -> Tuple[bool, Set[int]]:
+    """Persist one user's full snapshot.
+
+    Returns (ok, removed_goal_ids): goal ids that existed before this save but
+    are gone (or soft-deleted) now — the caller cascades them out of the
+    knowledge base.
+    """
+    user_id = str(user_id)
+    try:
+        conn = _connect(db_path())
+        try:
+            conn.executescript(_SCHEMA)
+            with conn:
+                before = {
+                    row[0] for row in conn.execute(
+                        "SELECT id FROM goals WHERE user_id=?", (user_id,)
+                    )
+                }
+                goals = snapshot.get("goals") or []
+                keep: Set[int] = set()
+                for goal in goals if isinstance(goals, list) else []:
+                    if not isinstance(goal, dict) or goal.get("id") is None:
+                        continue
+                    gid = int(goal["id"])
+                    keep.add(gid)
+                    conn.execute(
+                        "INSERT INTO goals(user_id, id, data) VALUES(?, ?, ?) "
+                        "ON CONFLICT(user_id, id) DO UPDATE SET data=excluded.data",
+                        (user_id, gid, _dump(goal)),
+                    )
+                conn.execute(
+                    "DELETE FROM goals WHERE user_id=?"
+                    + (f" AND id NOT IN ({','.join('?' * len(keep))})" if keep else ""),
+                    (user_id, *keep),
+                )
+                removed = {gid for gid in before if gid not in keep}
+                # Soft-deleted goals (is_deleted) are treated as removed for KB
+                # cascade purposes but their rows stay for potential restore.
+                for goal in goals if isinstance(goals, list) else []:
+                    if isinstance(goal, dict) and goal.get("is_deleted"):
+                        try:
+                            removed.add(int(goal["id"]))
+                        except (TypeError, ValueError):
+                            pass
+
+                conn.execute("DELETE FROM mastery_history WHERE user_id=?", (user_id,))
+                history = snapshot.get("learned_skills_history") or {}
+                if isinstance(history, dict):
+                    rows = []
+                    for gid, entries in history.items():
+                        if not isinstance(entries, list):
+                            continue
+                        for entry in entries:
+                            if isinstance(entry, dict) and "rate" in entry:
+                                rows.append((user_id, int(gid),
+                                             float(entry.get("ts", 0.0) or 0.0),
+                                             float(entry["rate"])))
+                            elif isinstance(entry, (int, float)):
+                                rows.append((user_id, int(gid), time.time(), float(entry)))
+                    conn.executemany(
+                        "INSERT OR REPLACE INTO mastery_history(user_id, goal_id, ts, rate) "
+                        "VALUES(?, ?, ?, ?)", rows,
+                    )
+
+                for key in _DICT_OF_BLOBS:
+                    mapping = snapshot.get(key)
+                    if not isinstance(mapping, dict):
+                        continue
+                    conn.execute("DELETE FROM blobs WHERE user_id=? AND kind=?", (user_id, key))
+                    conn.executemany(
+                        "INSERT OR REPLACE INTO blobs(user_id, kind, uid, data) VALUES(?, ?, ?, ?)",
+                        [(user_id, key, str(uid), _dump(blob)) for uid, blob in mapping.items()],
+                    )
+                for key, value in snapshot.items():
+                    if key.startswith(_QUIZ_PREFIX):
+                        conn.execute(
+                            "INSERT OR REPLACE INTO blobs(user_id, kind, uid, data) VALUES(?, ?, ?, ?)",
+                            (user_id, "quiz_results", key, _dump(value)),
+                        )
+
+                skip = _DICT_OF_BLOBS | {"goals", "learned_skills_history"}
+                conn.executemany(
+                    "INSERT INTO kv(user_id, key, value) VALUES(?, ?, ?) "
+                    "ON CONFLICT(user_id, key) DO UPDATE SET value=excluded.value",
+                    [(user_id, key, _dump(value))
+                     for key, value in snapshot.items()
+                     if key not in skip and not key.startswith(_QUIZ_PREFIX)],
+                )
+        finally:
+            conn.close()
+        return True, removed
+    except (sqlite3.Error, TypeError, ValueError) as exc:
+        logger.error("Could not persist state for user %s: %s", user_id, exc, exc_info=True)
+        return False, set()
+
+
+def load_snapshot(user_id: str) -> Dict[str, Any]:
+    """Read one user's snapshot back; {} when the user has no state yet."""
+    user_id = str(user_id)
+    path = db_path()
+    if not path.exists():
+        return {}
+    try:
+        conn = _connect(path)
+        try:
+            conn.executescript(_SCHEMA)
+            snapshot: Dict[str, Any] = {}
+            for key, value in conn.execute(
+                "SELECT key, value FROM kv WHERE user_id=?", (user_id,)
+            ):
+                snapshot[key] = _load(value)
+            snapshot["goals"] = [
+                _load(row[0]) for row in
+                conn.execute("SELECT data FROM goals WHERE user_id=? ORDER BY id", (user_id,))
+            ]
+            history: Dict[str, List[Dict[str, Any]]] = {}
+            for gid, ts, rate in conn.execute(
+                "SELECT goal_id, ts, rate FROM mastery_history WHERE user_id=? "
+                "ORDER BY goal_id, ts", (user_id,),
+            ):
+                history.setdefault(str(gid), []).append({"ts": ts, "rate": rate})
+            snapshot["learned_skills_history"] = history
+            for kind in _DICT_OF_BLOBS:
+                mapping = {
+                    uid: _load(data) for uid, data in conn.execute(
+                        "SELECT uid, data FROM blobs WHERE user_id=? AND kind=?", (user_id, kind)
+                    )
+                }
+                if mapping:
+                    snapshot[kind] = mapping
+            for uid_key, data in conn.execute(
+                "SELECT uid, data FROM blobs WHERE user_id=? AND kind='quiz_results'", (user_id,)
+            ):
+                snapshot[uid_key] = _load(data)
+            return snapshot
+        finally:
+            conn.close()
+    except (sqlite3.Error, ValueError) as exc:
+        logger.error("Could not read state for user %s: %s", user_id, exc, exc_info=True)
+        return {}
+
+
+def reset_user(user_id: str) -> bool:
+    """Archive the user's snapshot into state_backups, then wipe their rows.
+
+    The archive-first ordering mirrors the frontend's reset semantics: a failed
+    backup leaves the data in place rather than destroying it.
+    """
+    user_id = str(user_id)
+    try:
+        snapshot = load_snapshot(user_id)
+        conn = _connect(db_path())
+        try:
+            conn.executescript(_SCHEMA)
+            with conn:
+                if snapshot:
+                    conn.execute(
+                        "INSERT OR REPLACE INTO state_backups(user_id, created_at, snapshot) "
+                        "VALUES(?, ?, ?)",
+                        (user_id, time.time(), _dump(snapshot)),
+                    )
+                for table, where in (
+                    ("kv", "user_id=?"), ("goals", "user_id=?"),
+                    ("blobs", "user_id=?"), ("mastery_history", "user_id=?"),
+                ):
+                    conn.execute(f"DELETE FROM {table} WHERE {where}", (user_id,))
+        finally:
+            conn.close()
+        return True
+    except sqlite3.Error as exc:
+        logger.error("Could not reset state for user %s: %s", user_id, exc, exc_info=True)
+        return False
+
+
+def goal_ids_for_user(user_id: str) -> Set[int]:
+    try:
+        conn = _connect(db_path())
+        try:
+            return {row[0] for row in conn.execute(
+                "SELECT id FROM goals WHERE user_id=?", (str(user_id),)
+            )}
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return set()

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -1,13 +1,11 @@
 import logging
-import shutil
 import time
-from datetime import datetime
 from pathlib import Path
 
 import streamlit as st
 from streamlit.errors import StreamlitAPIException
 
-from utils.state import initialize_session_state, save_persistent_state, _get_data_store_path
+from utils.state import initialize_session_state, save_persistent_state
 from utils import data_store
 from config import asset_path
 
@@ -45,22 +43,6 @@ def _switch_page(page: str) -> bool:
     return True
 
 
-def _reset_data_store(path: Path) -> None:
-    """Archive the SQLite data store under a timestamped name, then delete it.
-
-    The archive is written first on purpose: if it cannot be created the store is
-    left in place rather than destroyed without a backup. WAL/SHM siblings are
-    removed alongside the db file.
-    """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    if not path.exists():
-        return
-    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
-    shutil.copy2(str(path), str(path.parent / f"data_storage-{ts}.db"))
-    for sibling in data_store.db_files(path):
-        sibling.unlink(missing_ok=True)
-
-
 initialize_session_state()
 st.session_state.setdefault("_autosave_enabled", True)
 
@@ -81,14 +63,12 @@ def show_reset_dialog():
     col_confirm, _space, col_cancel = st.columns([1, 2, 0.7])
     with col_confirm:
         if st.button("Confirm", type="primary"):
-            # Stop autosaving first, so nothing recreates the store we are about to remove.
+            # Stop autosaving first, so nothing recreates the server state we
+            # are about to remove.
             st.session_state["_autosave_enabled"] = False
-            data_path = _get_data_store_path()
-            try:
-                _reset_data_store(data_path)
-            except OSError as exc:
-                logger.error("Failed to reset data store at %s: %s", data_path, exc, exc_info=True)
-                st.error(f"Could not clear saved data: {exc}")
+            user_id = str(st.session_state.get("userId", "TestUser"))
+            if not data_store.reset_state(user_id):
+                st.error("Could not clear saved data: the backend did not confirm the reset.")
             st.session_state.clear()
             # switch_page targets run without re-executing this script, so the
             # defaults must be rebuilt here or every downstream key

--- a/frontend/utils/data_store.py
+++ b/frontend/utils/data_store.py
@@ -1,21 +1,15 @@
-"""SQLite-backed persistence for the frontend session state.
+"""State persistence client: the store lives in the BACKEND, not here.
 
-Replaces the single JSON file (user_data/data_store.json): WAL journaling and
-per-key upserts make concurrent tabs last-write-wins per key instead of
-clobbering the whole file, and the mastery history becomes real-timestamped
-rows instead of wall-clock samples.
+The frontend keeps session_state as a cache and pushes/pulls whole snapshots
+over the state API (GET/PUT /state, DELETE /state/{user_id}). The backend owns
+the SQLite file, keys everything by user, and cascades goal deletion into the
+knowledge base.
 
-Layout (key -> table routing):
-    goals                    -> goals(id, data)
-    learned_skills_history   -> mastery_history(goal_id, ts, rate)
-    document_caches /        -> blobs(kind, uid, data)   one row per uid
-    content_pipeline_state /
-    session_learning_times
-    quiz_results_* (any key starting with that prefix)
-    everything else          -> kv(key, value)
-
-The first load migrates an existing data_store.json in place and renames it
-to .migrated (kept as a backup).
+One-time migration: the first successful contact with an EMPTY remote store
+uploads whatever legacy state exists locally (the old SQLite db or, older
+still, the JSON file) and parks the local copy as *.migrated — so upgrading
+users keep their data. If the backend is unreachable, callers degrade to a
+fresh session (logged) and the migration is retried on a later run.
 """
 
 from __future__ import annotations
@@ -23,236 +17,154 @@ from __future__ import annotations
 import json
 import logging
 import sqlite3
-import time
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, Optional
+
+import httpx
+
+import config
 
 logger = logging.getLogger(__name__)
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS kv (key TEXT PRIMARY KEY, value TEXT NOT NULL);
-CREATE TABLE IF NOT EXISTS goals (id INTEGER PRIMARY KEY, data TEXT NOT NULL);
-CREATE TABLE IF NOT EXISTS blobs (
-    kind TEXT NOT NULL,
-    uid TEXT NOT NULL,
-    data TEXT NOT NULL,
-    PRIMARY KEY (kind, uid)
-);
-CREATE TABLE IF NOT EXISTS mastery_history (
-    goal_id INTEGER NOT NULL,
-    ts REAL NOT NULL,
-    rate REAL NOT NULL,
-    PRIMARY KEY (goal_id, ts)
-);
-"""
+USER_DATA_DIR = Path(__file__).resolve().parents[1] / "user_data"
+_LOCAL_DB = USER_DATA_DIR / "data_store.db"
+_LOCAL_JSON = USER_DATA_DIR / "data_store.json"
 
-# Top-level session keys whose value is a {uid: blob} mapping.
 _DICT_OF_BLOBS = {"document_caches", "content_pipeline_state", "session_learning_times"}
 _QUIZ_PREFIX = "quiz_results_"
+_TIMEOUT = 30
 
 
-def _connect(path: Path) -> sqlite3.Connection:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(path, timeout=5.0)
-    conn.execute("PRAGMA journal_mode=WAL")
-    conn.execute("PRAGMA busy_timeout=3000")
-    conn.execute("PRAGMA synchronous=NORMAL")
-    return conn
-
-
-def _ensure_schema(conn: sqlite3.Connection) -> None:
-    conn.executescript(_SCHEMA)
-    conn.commit()
-
-
-def _dump(value: Any) -> str:
-    return json.dumps(value, ensure_ascii=False)
-
-
-def _load(value: str) -> Any:
-    return json.loads(value)
-
-
-def save_snapshot(path: Path, snapshot: Dict[str, Any]) -> bool:
-    """Persist one full state snapshot, routing each key to its table."""
+def _base_url() -> str:
+    # Local import keeps this module importable without streamlit (tests).
     try:
-        conn = _connect(path)
-        try:
-            _ensure_schema(conn)
-            with conn:
-                # goals (upsert; drop rows whose id disappeared this session)
-                goals = snapshot.get("goals") or []
-                keep_ids = []
-                for goal in goals if isinstance(goals, list) else []:
-                    gid = goal.get("id") if isinstance(goal, dict) else None
-                    if gid is None:
-                        continue
-                    keep_ids.append(int(gid))
-                    conn.execute(
-                        "INSERT INTO goals(id, data) VALUES(?, ?) "
-                        "ON CONFLICT(id) DO UPDATE SET data=excluded.data",
-                        (int(gid), _dump(goal)),
-                    )
-                if keep_ids:
-                    conn.execute(
-                        f"DELETE FROM goals WHERE id NOT IN ({','.join('?' * len(keep_ids))})",
-                        keep_ids,
-                    )
-                else:
-                    conn.execute("DELETE FROM goals")
+        import streamlit as st
 
-                # mastery history: replace-all (small table, real timestamps)
-                conn.execute("DELETE FROM mastery_history")
-                history = snapshot.get("learned_skills_history") or {}
-                if isinstance(history, dict):
-                    rows = []
-                    for gid, entries in history.items():
-                        if not isinstance(entries, list):
-                            continue
-                        for entry in entries:
-                            if isinstance(entry, dict) and "rate" in entry:
-                                rows.append((int(gid), float(entry.get("ts", 0.0) or 0.0),
-                                             float(entry["rate"])))
-                            elif isinstance(entry, (int, float)):
-                                # legacy plain-rate entries: stamp them now
-                                rows.append((int(gid), time.time(), float(entry)))
-                    conn.executemany(
-                        "INSERT OR REPLACE INTO mastery_history(goal_id, ts, rate) VALUES(?, ?, ?)",
-                        rows,
-                    )
+        endpoint = st.session_state.get("backend_endpoint") or config.backend_endpoint
+    except Exception:
+        endpoint = config.backend_endpoint
+    return str(endpoint).rstrip("/") + "/"
 
-                # uid-keyed blob maps and quiz_results_* keys
-                for key in _DICT_OF_BLOBS:
-                    mapping = snapshot.get(key)
-                    if not isinstance(mapping, dict):
-                        continue
-                    conn.execute("DELETE FROM blobs WHERE kind=?", (key,))
-                    conn.executemany(
-                        "INSERT OR REPLACE INTO blobs(kind, uid, data) VALUES(?, ?, ?)",
-                        [(key, str(uid), _dump(blob)) for uid, blob in mapping.items()],
-                    )
-                for key, value in snapshot.items():
-                    if key.startswith(_QUIZ_PREFIX):
-                        conn.execute(
-                            "INSERT OR REPLACE INTO blobs(kind, uid, data) VALUES(?, ?, ?)",
-                            ("quiz_results", key, _dump(value)),
-                        )
 
-                # simple keys -> kv
-                skip = _DICT_OF_BLOBS | {"goals", "learned_skills_history"}
-                kv_rows = [
-                    (key, _dump(value))
-                    for key, value in snapshot.items()
-                    if key not in skip and not key.startswith(_QUIZ_PREFIX)
-                ]
-                conn.executemany(
-                    "INSERT INTO kv(key, value) VALUES(?, ?) "
-                    "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
-                    kv_rows,
-                )
-        finally:
-            conn.close()
+def _remote_is_empty(snapshot: Dict[str, Any]) -> bool:
+    """True when the backend holds nothing meaningful for this user."""
+    if not isinstance(snapshot, dict):
         return True
-    except (sqlite3.Error, TypeError, ValueError) as exc:
-        logger.error("Could not persist state to %s: %s", path, exc, exc_info=True)
+    if snapshot.get("goals"):
+        return False
+    structural = {"goals", "learned_skills_history"}
+    return not any(k for k in snapshot if k not in structural)
+
+
+# ------------------------------------------------------------------
+# backend API
+# ------------------------------------------------------------------
+
+def load_state(user_id: str) -> Optional[Dict[str, Any]]:
+    """Fetch the user's snapshot.
+
+    Returns None when the backend is unreachable (distinct from {} which means
+    "reachable and genuinely empty") — callers use that distinction to refuse
+    saving an unvalidated empty session over server-side data.
+    """
+    try:
+        response = httpx.get(f"{_base_url()}state", params={"user_id": str(user_id)},
+                             timeout=_TIMEOUT)
+        response.raise_for_status()
+        snapshot = response.json().get("snapshot") or {}
+    except httpx.HTTPError as exc:
+        logger.warning("State backend unreachable, starting with empty state: %s", exc)
+        return None
+    if _remote_is_empty(snapshot):
+        migrated = _migrate_local_if_any(str(user_id))
+        if migrated:
+            return migrated
+    return snapshot
+
+
+def save_state(user_id: str, snapshot: Dict[str, Any]) -> bool:
+    try:
+        response = httpx.put(f"{_base_url()}state",
+                             json={"user_id": str(user_id), "snapshot": snapshot},
+                             timeout=_TIMEOUT)
+        return response.status_code == 200
+    except httpx.HTTPError as exc:
+        logger.warning("Could not persist state to backend: %s", exc)
         return False
 
 
-def load_snapshot(path: Path) -> Dict[str, Any]:
-    """Read the whole store back into the snapshot dict shape.
-
-    Migrates an existing JSON store on first use. Returns {} when there is
-    nothing to restore (fresh install or unreadable store — logged).
-    """
-    legacy_json = path.parent / "data_store.json"
+def reset_state(user_id: str) -> bool:
+    """Archive + wipe the user's server-side state (the Reset flow)."""
     try:
-        conn = _connect(path)
-        try:
-            _ensure_schema(conn)
-            fresh = conn.execute("SELECT COUNT(*) FROM kv").fetchone()[0] == 0 \
-                and conn.execute("SELECT COUNT(*) FROM goals").fetchone()[0] == 0
-            if fresh and legacy_json.exists():
-                _migrate_json(conn, legacy_json)
-            snapshot: Dict[str, Any] = {}
+        response = httpx.delete(f"{_base_url()}state/{user_id}", timeout=_TIMEOUT)
+        return response.status_code == 200
+    except httpx.HTTPError as exc:
+        logger.error("Could not reset backend state: %s", exc)
+        return False
 
-            for key, value in conn.execute("SELECT key, value FROM kv"):
-                snapshot[key] = _load(value)
-            snapshot["goals"] = [
-                _load(row[0]) for row in
-                conn.execute("SELECT data FROM goals ORDER BY id")
-            ]
-            history: Dict[str, List[Dict[str, Any]]] = {}
-            for gid, ts, rate in conn.execute(
-                "SELECT goal_id, ts, rate FROM mastery_history ORDER BY goal_id, ts"
-            ):
-                history.setdefault(str(gid), []).append({"ts": ts, "rate": rate})
-            snapshot["learned_skills_history"] = history
 
-            for kind in _DICT_OF_BLOBS:
-                mapping = {
-                    uid: _load(data) for uid, data in
-                    conn.execute("SELECT uid, data FROM blobs WHERE kind=?", (kind,))
-                }
-                if mapping or kind in snapshot:
-                    snapshot[kind] = mapping
-            for uid_key, data in conn.execute(
-                "SELECT uid, data FROM blobs WHERE kind='quiz_results'"
-            ):
-                snapshot[uid_key] = _load(data)
-            return snapshot
-        finally:
-            conn.close()
-    except (sqlite3.Error, ValueError) as exc:
-        logger.error("Could not read persisted state from %s: %s", path, exc, exc_info=True)
+# ------------------------------------------------------------------
+# one-time local -> backend migration
+# ------------------------------------------------------------------
+
+def _migrate_local_if_any(user_id: str) -> Dict[str, Any]:
+    """Upload legacy local state to the empty backend; returns it on success."""
+    snapshot = _read_local_snapshot()
+    if not snapshot or _remote_is_empty(snapshot):
         return {}
+    if not save_state(user_id, snapshot):
+        return {}  # backend flaked mid-migration: retry next run
+    for path in (_LOCAL_DB, Path(str(_LOCAL_DB) + "-wal"), Path(str(_LOCAL_DB) + "-shm")):
+        if path.exists():
+            path.rename(path.with_name(path.name + ".migrated"))
+    if _LOCAL_JSON.exists():
+        _LOCAL_JSON.rename(_LOCAL_JSON.with_name(_LOCAL_JSON.name + ".migrated"))
+    logger.info("Migrated local state to the backend store (local copy parked as .migrated).")
+    return snapshot
 
 
-def _migrate_json(conn: sqlite3.Connection, legacy_json: Path) -> None:
-    """Import the old flat-JSON store once, then park it as a backup."""
+def _read_local_snapshot() -> Dict[str, Any]:
+    """Read the legacy local store: SQLite first, falling back to the JSON file."""
+    if _LOCAL_DB.exists():
+        try:
+            return _read_local_sqlite(_LOCAL_DB)
+        except (sqlite3.Error, ValueError) as exc:
+            logger.error("Legacy store %s unreadable: %s", _LOCAL_DB, exc)
+    if _LOCAL_JSON.exists():
+        try:
+            data = json.loads(_LOCAL_JSON.read_text(encoding="utf-8"))
+            return data if isinstance(data, dict) else {}
+        except (OSError, ValueError) as exc:
+            logger.error("Legacy store %s unreadable: %s", _LOCAL_JSON, exc)
+    return {}
+
+
+def _read_local_sqlite(path: Path) -> Dict[str, Any]:
+    conn = sqlite3.connect(path, timeout=5.0)
     try:
-        data = json.loads(legacy_json.read_text(encoding="utf-8"))
-    except (OSError, ValueError) as exc:
-        logger.error("Legacy store %s unreadable, skipping migration: %s", legacy_json, exc)
-        return
-    if not isinstance(data, dict):
-        logger.error("Legacy store %s is not a JSON object, skipping migration.", legacy_json)
-        return
-    with conn:
-        for key, value in data.items():
-            if key == "goals" and isinstance(value, list):
-                for goal in value:
-                    if isinstance(goal, dict) and goal.get("id") is not None:
-                        conn.execute(
-                            "INSERT OR REPLACE INTO goals(id, data) VALUES(?, ?)",
-                            (int(goal["id"]), _dump(goal)),
-                        )
-            elif key == "learned_skills_history" and isinstance(value, dict):
-                for gid, entries in value.items():
-                    if isinstance(entries, list):
-                        for entry in entries:
-                            ts, rate = (time.time(), float(entry)) if isinstance(entry, (int, float)) \
-                                else (float(entry.get("ts", 0.0) or 0.0), float(entry.get("rate", 0.0)))
-                            conn.execute(
-                                "INSERT OR REPLACE INTO mastery_history(goal_id, ts, rate) VALUES(?, ?, ?)",
-                                (int(gid), ts, rate),
-                            )
-            elif key in _DICT_OF_BLOBS and isinstance(value, dict):
-                conn.executemany(
-                    "INSERT OR REPLACE INTO blobs(kind, uid, data) VALUES(?, ?, ?)",
-                    [(key, str(uid), _dump(blob)) for uid, blob in value.items()],
-                )
-            else:
-                conn.execute(
-                    "INSERT OR REPLACE INTO kv(key, value) VALUES(?, ?)", (key, _dump(value))
-                )
-    backup = legacy_json.with_suffix(".json.migrated")
-    try:
-        legacy_json.rename(backup)
-        logger.info("Migrated legacy JSON store to SQLite; original kept at %s", backup)
-    except OSError as exc:
-        logger.warning("Migrated store but could not rename %s: %s", legacy_json, exc)
-
-
-def db_files(path: Path) -> List[Path]:
-    """The db plus its WAL/SHM siblings (for archive/reset flows)."""
-    return [path, Path(str(path) + "-wal"), Path(str(path) + "-shm")]
+        snapshot: Dict[str, Any] = {}
+        for key, value in conn.execute("SELECT key, value FROM kv"):
+            snapshot[key] = json.loads(value)
+        snapshot["goals"] = [
+            json.loads(row[0]) for row in conn.execute("SELECT data FROM goals ORDER BY id")
+        ]
+        history: Dict[str, Any] = {}
+        for gid, ts, rate in conn.execute(
+            "SELECT goal_id, ts, rate FROM mastery_history ORDER BY goal_id, ts"
+        ):
+            history.setdefault(str(gid), []).append({"ts": ts, "rate": rate})
+        snapshot["learned_skills_history"] = history
+        for kind in _DICT_OF_BLOBS:
+            mapping = {
+                uid: json.loads(data) for uid, data in
+                conn.execute("SELECT uid, data FROM blobs WHERE kind=?", (kind,))
+            }
+            if mapping:
+                snapshot[kind] = mapping
+        for uid_key, data in conn.execute(
+            "SELECT uid, data FROM blobs WHERE kind='quiz_results'"
+        ):
+            snapshot[uid_key] = json.loads(data)
+        return snapshot
+    finally:
+        conn.close()

--- a/frontend/utils/state.py
+++ b/frontend/utils/state.py
@@ -1,7 +1,6 @@
 import streamlit as st
 import config
 import logging
-from pathlib import Path
 
 from utils import data_store
 
@@ -37,11 +36,6 @@ PERSIST_KEYS = [
 ]
 
 
-def _get_data_store_path():
-    """SQLite store (WAL). The pre-SQLite JSON store auto-migrates on first load."""
-    return Path(__file__).resolve().parents[1] / "user_data" / "data_store.db"
-
-
 def _persistable_keys():
     """PERSIST_KEYS plus any quiz_results_* keys currently in session state.
 
@@ -54,15 +48,22 @@ def _persistable_keys():
     ]
 
 
-def load_persistent_state():
-    """Restore persisted keys from the SQLite store into st.session_state.
+def _current_user_id() -> str:
+    return str(st.session_state.get("userId", "TestUser"))
 
-    Only keys listed in PERSIST_KEYS (plus quiz_results_*) are restored.
-    Returns False if there is nothing to restore or the store could not be
-    read; a store that exists but is unreadable is logged rather than ignored.
+
+def load_persistent_state():
+    """Restore persisted keys from the BACKEND state store into st.session_state.
+
+    The backend owns the database (keyed by user id); this side keeps only a
+    session cache. Returns False when there is nothing to restore or the
+    backend is unreachable (logged; the app then starts fresh).
     """
-    snapshot = data_store.load_snapshot(_get_data_store_path())
-    if not snapshot:
+    snapshot = data_store.load_state(_current_user_id())
+    # None = backend unreachable. Remember it: saving the (empty) session over
+    # server data after a failed read would destroy the user's state.
+    st.session_state["_state_backend_ok"] = snapshot is not None
+    if snapshot is None:
         return False
     restored = False
     for k, v in snapshot.items():
@@ -73,14 +74,25 @@ def load_persistent_state():
 
 
 def save_persistent_state():
-    """Persist whitelisted st.session_state keys to the SQLite store.
+    """Push whitelisted st.session_state keys to the backend state store.
 
     Returns True on success. Failures are logged and reported as False; callers
     that can show UI (see `_autosave` in main.py) surface them to the user.
     """
+    if not st.session_state.get("_state_backend_ok", False):
+        # Never overwrite the server store from a session that never read it
+        # successfully — an unreachable backend at startup must not turn the
+        # first autosave into a wipe.
+        if not st.session_state.get("_state_save_guard_warned", False):
+            st.session_state["_state_save_guard_warned"] = True
+            logger.warning(
+                "Skipping state save: the backend store was never read successfully "
+                "this session (guarding server data against an empty overwrite)."
+            )
+        return False
     keys = _persistable_keys()
     snapshot = {k: st.session_state[k] for k in keys if k in st.session_state}
-    return data_store.save_snapshot(_get_data_store_path(), snapshot)
+    return data_store.save_state(_current_user_id(), snapshot)
 
 
 def initialize_session_state():


### PR DESCRIPTION
## Summary

The database now lives in the backend. The frontend keeps session_state as a cache and pushes/pulls whole snapshots over a small state API — `state.py`'s public API is unchanged, so all call sites are untouched.

### Backend (`utils/state_store.py` + `/state` API)
- Per-user SQLite (WAL): goals / blobs / mastery_history / kv tables + a `state_backups` archive; snapshot upserts routed per key
- `GET /state`, `PUT /state`, `DELETE /state/{user_id}` (archive-first reset)
- **KB cascade**: goals that vanish or are soft-deleted from a snapshot are unpinned from the knowledge base automatically; reset collects goal ids before wiping for the same cascade
- **Hardening**: non-dict snapshots → 400. Treating them as empty would silently wipe the user's server state (verified live: three malformed payloads, data byte-identical after)

### Frontend
- `data_store.py` is now a thin HTTP client; the migration chain (JSON → local SQLite → backend store) runs automatically on first contact with an empty remote and parks local copies as `*.migrated`
- **Wipe guard**: `load_state` distinguishes unreachable (`None`) from genuinely empty (`{}`); a session that never read the backend successfully refuses to save — a transient outage at startup can no longer overwrite server data with an empty snapshot (verified against a live backend returning 503)

### Architecture payoffs
- Deleting a goal now cascades its knowledge base; the UI is replaceable without data loss; multi-user only needs a real userId instead of the placeholder.

## Verification
- Suites: backend 88 passed + 1 xpassed (7 new state cases), frontend 13, full project compiles
- Live: real user data migrated intact (2 goals, 22 keys); malformed-payload attack leaves data untouched; backend-down scenario emits no PUT; post-everything data verified intact