### PR TITLE
docs: set genmentor.aurax.live as the primary site

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </p>
   <p><b>LLM-powered & Goal-oriented Tutoring System</b></p>
   <p>
-    <a href="https://gen-mentor.vercel.app">Live app</a> &nbsp;·&nbsp;
+    <a href="https://genmentor.aurax.live">Live app</a> &nbsp;·&nbsp;
     <a href="https://www.tianfuwang.tech/gen-mentor">Website</a> &nbsp;·&nbsp;
     <a href="https://arxiv.org/pdf/2501.15749">Paper</a> &nbsp;·&nbsp;
     <a href="https://youtu.be/vTdtGZop-Zc">Video</a>
@@ -82,7 +82,7 @@ No key at hand? `GENMENTOR_LLM_MODE=replay make dev` serves the recorded journey
 
 | Target | How |
 |---|---|
-| Vercel | The public instance at [gen-mentor.vercel.app](https://gen-mentor.vercel.app) ships without a server key: visitors add their own provider, key and models in **Model** settings. To run your own, import the repo with **Root Directory** `app` and optionally add the environment variables |
+| Vercel | The public instance at [genmentor.aurax.live](https://genmentor.aurax.live) ships without a server key: visitors add their own provider, key and models in **Model** settings. To run your own, import the repo with **Root Directory** `app` and optionally add the environment variables |
 | Container | `docker build -t genmentor app && docker run -p 3000:3000 --env-file app/.env.local genmentor` |
 
 ## Repository layout

--- a/wiki/02-system-architecture.md
+++ b/wiki/02-system-architecture.md
@@ -86,7 +86,7 @@ route 收到请求 → `parseBody(schema)` 校验 → `lib/agents/<agent>` 组�
 | 方式 | 做法 |
 |---|---|
 | 本地 | `make install && make dev`，只需 `app/.env.local` 里一个 LLM key |
-| Vercel | 项目 `gen-mentor`（team geminilights-projects），生产别名 https://gen-mentor.vercel.app ，Root Directory `app`，GitHub `main` 推送自动部署。生产环境不配任何 LLM 变量，访客自带 key（顶部横幅引导）。预览部署开着 Vercel Authentication，生产别名公开 |
+| Vercel | 项目 `gen-mentor`（team geminilights-projects），主域名 https://genmentor.aurax.live （旧地址 https://gen-mentor.vercel.app 保留用于原浏览器档案访问） ，Root Directory `app`，GitHub `main` 推送自动部署。生产环境不配任何 LLM 变量，访客自带 key（顶部横幅引导）。预览部署开着 Vercel Authentication，生产别名公开 |
 | 容器 | `docker build -t genmentor app/`，`docker run -p 3000:3000 --env-file app/.env.local genmentor`；镜像用 `.next/standalone` 单进程 |
 
 `GENMENTOR_LLM_MODE=replay` 加 `e2e/fixtures/llm` 可以在没有 key 的机器上完整演示已录制的旅程。
@@ -118,3 +118,8 @@ correct / incorrect 两种 verdict 作分母，简答题显示待自评，无可
 AppShell 只挂载一个按目标 ID 隔离的导师会话，桌面和手机入口共享它。展示模式与展开状态
 由 `genmentor.tutor-panel.v1` 独立保存；刷新只恢复已固定且展开的面板。会话 hook 持有草稿、
 请求与流式文本，抽屉/固定侧栏仅改变展示容器。切换目标卸载旧会话并中止旧请求。
+
+主域名 DNS 由 Cloudflare 管理：`genmentor` CNAME 指向 Vercel 分配的
+`11e1c9bf0df68f4a.vercel-dns-017.com`，采用 DNS-only；2026-09-10 验证与 HTTPS 访问通过。
+学习档案和模型配置按浏览器 origin 隔离。切换域名时从旧站导出学习档案、在新站导入，
+模型凭证在新站重新配置，因此旧站暂不强制跳转。后续 main 部署继续绑定新主域名。


### PR DESCRIPTION
Set https://genmentor.aurax.live as the public site in the README and deployment documentation. The custom domain is bound to the existing Vercel production project and its Cloudflare DNS configuration is verified.

Keep the old Vercel address accessible so existing users can export origin-local learning archives before importing them on the new domain. Model credentials must be configured separately on the new origin.

Validation: Vercel domain verification reports configured correctly; HTTPS returns 200; a browser smoke check on the custom domain confirms onboarding hydration, the Adaptive default, and hidden Goals for an empty archive. This change only updates documentation.
